### PR TITLE
change create_training_job_definition_version interface

### DIFF
--- a/abeja/train/api/client.py
+++ b/abeja/train/api/client.py
@@ -233,7 +233,7 @@ class APIClient(BaseAPIClient):
 
                 organization_id = "1102940376065"
                 job_definition_name = "test_job_definition"
-                source_code = open("./train.py")
+                source_code = open("./train.zip", "rb")
                 handler = "train:handler"
                 image = "abeja-inc/all-gpu:19.04"
                 environment = {"key": "value"}


### PR DESCRIPTION
API 同様に `source_code` に直接バイト列を指定したい場合もあると想定し `filepaths` に加えて直接 file-like object を受け取れるように変更しました．