### PR TITLE
Send all params/metrics to statistics from tracker

### DIFF
--- a/abeja/tracking/__init__.py
+++ b/abeja/tracking/__init__.py
@@ -126,14 +126,20 @@ class Tracking:
         self._summary_writer.flush()
         if self._is_valid_job and self._total_steps is not None and self._step is not None:
             statistics = ABEJAStatistics(num_epochs=self._total_steps, epoch=self._step)
+            kwargs = {**self._params, **self._metrics}
+            kwargs.pop('main_acc', None)
+            kwargs.pop('main_loss', None)
+            kwargs.pop('test_acc', None)
+            kwargs.pop('test_loss', None)
+
             train_acc = self._metrics.get('main_acc')
             train_loss = self._metrics.get('main_loss')
             if train_acc is not None or train_loss is not None:
-                statistics.add_stage(ABEJAStatistics.STAGE_TRAIN, train_acc, train_loss)
+                statistics.add_stage(ABEJAStatistics.STAGE_TRAIN, train_acc, train_loss, **kwargs)
             val_acc = self._metrics.get('test_acc')
             val_loss = self._metrics.get('test_loss')
             if val_acc is not None or val_loss is not None:
-                statistics.add_stage(ABEJAStatistics.STAGE_VALIDATION, val_acc, val_loss)
+                statistics.add_stage(ABEJAStatistics.STAGE_VALIDATION, val_acc, val_loss, **kwargs)
             if statistics.get_statistics():
                 try:
                     res = TrainingClient().update_statistics(

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -241,7 +241,15 @@ class TestTracking(unittest.TestCase):
                 tk.log_metric(key='main/loss', value=0.5)
                 tk.log_metric(key='test/acc', value=0.5)
                 tk.log_metric(key='test/loss', value=0.5)
+                tk.log_param(key='dummy', value='dummy')
         self.assertEqual(2, m_update_statistics.call_count)
+        expect = {
+            'dummy': 'dummy',
+            'accuracy': 0.5,
+            'loss': 0.5
+        }
+        self.assertDictEqual(expect, m_update_statistics.call_args[1]['statistics']['stages']['train'])
+        self.assertDictEqual(expect, m_update_statistics.call_args[1]['statistics']['stages']['validation'])
 
     @mock.patch('abeja.train.api.client.APIClient.update_statistics')
     def test_tracking_statistics_not_work(self, m_update_statistics):


### PR DESCRIPTION
Trackerからすべてのparams/metricsをStatisticsに送るようにしました。

## Related Issue
https://github.com/abeja-inc/platform-planning/issues/3293