### PR TITLE
High Level APIs for training job definition versions

### DIFF
--- a/abeja/training/api/client.py
+++ b/abeja/training/api/client.py
@@ -528,6 +528,59 @@ class APIClient(BaseAPIClient):
             organization_id, job_definition_name, version_id)
         return self._connection.api_request(method='GET', path=path)
 
+    def patch_training_job_definition_version(
+            self, organization_id: str, job_definition_name: str, version_id: int,
+            description: str) -> dict:
+        """Update a training job definition version
+
+        API reference: PATCH /organizations/<organization_id>/training/definitions/<job_definition_name>/versions/<version_id>
+
+        Request Syntax:
+            .. code-block:: python
+
+                organization_id = "1102940376065"
+                job_definition_name = "test_job_definition"
+                version_id = 1
+                response = api_client.patch_training_job_definition_version(organization_id, job_definition_name, version_id, description='new version')
+
+        Params:
+            - **organization_id** (str): ORGANIZATION_ID
+            - **job_definition_name** (str): training job definition name
+            - **version_id** (int): training job version
+            - **description** (str): description
+
+        Return type:
+            dict
+
+        Returns:
+            Response Syntax:
+
+            .. code-block:: json
+
+                {
+                    "job_definition_version": 1,
+                    "user_parameters": {},
+                    "datasets": {
+                        "mnist": "1111111111111"
+                    },
+                    "modified_at": "2018-05-17T12:34:46.344076Z",
+                    "job_definition_id": "1443714239154",
+                    "handler": "train:handler",
+                    "created_at": "2018-05-17T12:34:46.296488Z",
+                    "image": "abeja-inc/all-gpu:19.04",
+                    "archived": false
+                }
+
+        Raises:
+            - BadRequest
+            - Unauthorized: Authentication failed
+            - InternalServerError
+        """
+        path = '/organizations/{}/training/definitions/{}/versions/{}'.format(
+            organization_id, job_definition_name, version_id)
+        params = {'description': description}
+        return self._connection.api_request(method='PATCH', path=path, json=params)
+
     def delete_training_job_definition_version(
             self, organization_id: str, job_definition_name: str, version_id: int) -> dict:
         """delete a training job definition version

--- a/abeja/training/api/client.py
+++ b/abeja/training/api/client.py
@@ -64,7 +64,7 @@ class APIClient(BaseAPIClient):
         path = '/organizations/{}/training/definitions/'.format(organization_id)
         return self._connection.api_request(method='POST', path=path, json=data)
 
-    def archive_training_job_definition(self, organization_id: str, job_definition_name: str):
+    def archive_training_job_definition(self, organization_id: str, job_definition_name: str) -> dict:
         """archive a training job definition
 
         API reference: POST /organizations/<organization_id>/training/definitions/{name}/archive
@@ -89,7 +89,7 @@ class APIClient(BaseAPIClient):
         path = '/organizations/{}/training/definitions/{}/archive'.format(organization_id, job_definition_name)
         return self._connection.api_request(method='POST', path=path, json={})
 
-    def unarchive_training_job_definition(self, organization_id: str, job_definition_name: str):
+    def unarchive_training_job_definition(self, organization_id: str, job_definition_name: str) -> dict:
         """unarchive a training job definition
 
         API reference: POST /organizations/<organization_id>/training/definitions/{name}/unarchive
@@ -580,6 +580,46 @@ class APIClient(BaseAPIClient):
             organization_id, job_definition_name, version_id)
         params = {'description': description}
         return self._connection.api_request(method='PATCH', path=path, json=params)
+
+    def archive_training_job_definition_version(
+            self, organization_id: str, job_definition_name: str, version_id: int) -> dict:
+        """archive a training job definition version
+
+        API reference: POST /organizations/<organization_id>/training/definitions/<job_definition_name>/versions/<version_id>/archive
+
+        Request Syntax:
+            .. code-block:: python
+
+                organization_id = "1102940376065"
+                job_definition_name = "test_job_definition"
+                version_id = 1
+                response = api_client.archive_training_job_definition_version(organization_id, job_definition_name, version_id)
+
+        Params:
+            - **organization_id** (str): ORGANIZATION_ID
+            - **job_definition_name** (str): training job definition name
+            - **version_id** (int): training job version
+
+        Return type:
+            dict
+
+        Returns:
+            Response Syntax:
+
+            .. code-block:: json
+
+                {
+                    "message": "archived"
+                }
+
+        Raises:
+            - BadRequest
+            - Unauthorized: Authentication failed
+            - InternalServerError
+        """
+        path = '/organizations/{}/training/definitions/{}/versions/{}/archive'.format(
+            organization_id, job_definition_name, version_id)
+        return self._connection.api_request(method='POST', path=path)
 
     def delete_training_job_definition_version(
             self, organization_id: str, job_definition_name: str, version_id: int) -> dict:

--- a/abeja/training/api/client.py
+++ b/abeja/training/api/client.py
@@ -370,7 +370,7 @@ class APIClient(BaseAPIClient):
             - **job_definition_name** (str): training job definition name
             - **filepaths** (list): file list to run training job
             - **handler** (str): path to handler (ex. train:handler )
-            - **image** (Optional[str]): runtime enviornment
+            - **image** (Optional[str]): runtime environment
             - **environment** (Optional[dict]): user defined parameters set as environment variables
             - **description** (Optional[str]): description
 

--- a/abeja/training/api/client.py
+++ b/abeja/training/api/client.py
@@ -621,6 +621,46 @@ class APIClient(BaseAPIClient):
             organization_id, job_definition_name, version_id)
         return self._connection.api_request(method='POST', path=path)
 
+    def unarchive_training_job_definition_version(
+            self, organization_id: str, job_definition_name: str, version_id: int) -> dict:
+        """unarchive a training job definition version
+
+        API reference: POST /organizations/<organization_id>/training/definitions/<job_definition_name>/versions/<version_id>/unarchive
+
+        Request Syntax:
+            .. code-block:: python
+
+                organization_id = "1102940376065"
+                job_definition_name = "test_job_definition"
+                version_id = 1
+                response = api_client.unarchive_training_job_definition_version(organization_id, job_definition_name, version_id)
+
+        Params:
+            - **organization_id** (str): ORGANIZATION_ID
+            - **job_definition_name** (str): training job definition name
+            - **version_id** (int): training job version
+
+        Return type:
+            dict
+
+        Returns:
+            Response Syntax:
+
+            .. code-block:: json
+
+                {
+                    "message": "unarchived"
+                }
+
+        Raises:
+            - BadRequest
+            - Unauthorized: Authentication failed
+            - InternalServerError
+        """
+        path = '/organizations/{}/training/definitions/{}/versions/{}/unarchive'.format(
+            organization_id, job_definition_name, version_id)
+        return self._connection.api_request(method='POST', path=path)
+
     def delete_training_job_definition_version(
             self, organization_id: str, job_definition_name: str, version_id: int) -> dict:
         """delete a training job definition version

--- a/abeja/training/api/client.py
+++ b/abeja/training/api/client.py
@@ -689,16 +689,7 @@ class APIClient(BaseAPIClient):
             .. code-block:: json
 
                 {
-                    "job_definition_version": 1,
-                    "user_parameters": {},
-                    "datasets": {
-                        "mnist": "1111111111111"
-                    },
-                    "modified_at": "2018-05-17T12:34:46.344076Z",
-                    "job_definition_id": "1443714239154",
-                    "handler": "train:handler",
-                    "created_at": "2018-05-17T12:34:46.296488Z",
-                    "image": "abeja-inc/all-gpu:19.04"
+                    "message": "deleted"
                 }
 
         Raises:

--- a/abeja/training/job_definition.py
+++ b/abeja/training/job_definition.py
@@ -298,10 +298,10 @@ class JobDefinitions():
              offset: Optional[int] = None,
              limit: Optional[int] = None) -> SizedIterable[JobDefinition]:
         """Returns an iterator object that iterates training job definitions
-        under the this object's context.
+        under the this object.
 
         This method returns an instance of :class:`SizedIterable`, so you can
-        get the total number of training jobs.
+        get the total number of training job definitions.
 
         Params:
             - **filter_archived** (bool): **[optional]** whether include archived ones or not. (default is not-filtered)
@@ -435,6 +435,35 @@ class JobDefinitionVersions():
             organization_id=self.organization_id,
             response=res,
             job_definition=self.__job_definition)
+
+    def list(self, filter_archived: Optional[bool] = None) -> SizedIterable[JobDefinitionVersion]:
+        """Returns an iterator object that iterates training job definition versions
+        under the this object.
+
+        This method returns an instance of :class:`SizedIterable`, so you can
+        get the total number of training job definition versions.
+
+        Params:
+            - **filter_archived** (bool): **[optional]** whether include archived ones or not. (default is not-filtered)
+
+        Return type:
+            SizedIterable[JobDefinitionVersion]
+        """
+        res = self.__api.get_training_job_definition_versions(
+            organization_id=self.organization_id,
+            job_definition_name=self.job_definition_name,
+            filter_archived=filter_archived)
+
+        versions = [
+            JobDefinitionVersion.from_response(
+                api=self.__api,
+                organization_id=self.organization_id,
+                response=entry,
+                job_definition=self.__job_definition)
+            for entry in res['entries']]
+        # Because the SizedIterator<T> is not a true "Intersection Type" but is
+        # a new class, a list object will not be considered as adapted.
+        return cast(SizedIterable[JobDefinitionVersion], versions)
 
     def create(self,
                source: Union[List[str], IO[AnyStr]],

--- a/abeja/training/job_definition.py
+++ b/abeja/training/job_definition.py
@@ -435,6 +435,33 @@ class JobDefinitionVersions():
             response=res,
             job_definition=self.__job_definition)
 
+    def update(self, job_definition_version: int, description: str) -> JobDefinitionVersion:
+        """Update a training job definition version.
+
+        Request Syntax:
+            .. code-block:: python
+
+                version = versions.update(job_definition_version=5, description='new version')
+
+            Params:
+            - **job_definition_version** (int): the version number
+
+        Return type:
+            :class:`JobDefinitionVersion` object
+
+        """
+        res = self.__api.patch_training_job_definition_version(
+            organization_id=self.organization_id,
+            job_definition_name=self.job_definition_name,
+            version_id=job_definition_version,
+            description=description)
+
+        return JobDefinitionVersion.from_response(
+            api=self.__api,
+            organization_id=self.organization_id,
+            response=res,
+            job_definition=self.__job_definition)
+
 # Iterator classes
 
 

--- a/abeja/training/job_definition.py
+++ b/abeja/training/job_definition.py
@@ -574,6 +574,21 @@ class JobDefinitionVersions():
             job_definition_name=self.job_definition_name,
             version_id=job_definition_version)
 
+    def unarchive(self, job_definition_version: int):
+        """unarchive a training job definition version.
+
+        Request Syntax:
+            .. code-block:: python
+
+                versions.unarchive(job_definition_version=5)
+
+            Params:
+            - **job_definition_version** (int): the version number
+        """
+        self.__api.unarchive_training_job_definition_version(
+            organization_id=self.organization_id,
+            job_definition_name=self.job_definition_name,
+            version_id=job_definition_version)
 
 # Iterator classes
 

--- a/abeja/training/job_definition.py
+++ b/abeja/training/job_definition.py
@@ -1,4 +1,5 @@
 from typing import cast, Any, Dict, List, Iterator, Optional, Union, IO, AnyStr
+import io
 from .api.client import APIClient
 from .common import SizedIterable
 
@@ -466,25 +467,40 @@ class JobDefinitionVersions():
             :class:`JobDefinitionVersion` object
 
         """
-        parameters = {'handler': handler}  # type: Dict[str, Any]
-        if image is not None:
-            parameters['image'] = image
-        if environment is not None:
-            parameters['environment'] = environment
-        if description is not None:
-            parameters['description'] = description
+        if isinstance(source, io.IOBase):
+            parameters = {'handler': handler}  # type: Dict[str, Any]
+            if image is not None:
+                parameters['image'] = image
+            if environment is not None:
+                parameters['environment'] = environment
+            if description is not None:
+                parameters['description'] = description
 
-        res = self.__api.create_training_job_definition_version_native_api(
-            organization_id=self.organization_id,
-            job_definition_name=self.job_definition_name,
-            source_code=cast(IO[AnyStr], source),
-            parameters=parameters)
+            res = self.__api.create_training_job_definition_version_native_api(
+                organization_id=self.organization_id,
+                job_definition_name=self.job_definition_name,
+                source_code=cast(IO[AnyStr], source),
+                parameters=parameters)
 
-        return JobDefinitionVersion.from_response(
-            api=self.__api,
-            organization_id=self.organization_id,
-            response=res,
-            job_definition=self.__job_definition)
+            return JobDefinitionVersion.from_response(
+                api=self.__api,
+                organization_id=self.organization_id,
+                response=res,
+                job_definition=self.__job_definition)
+        else:
+            res = self.__api.create_training_job_definition_version(
+                organization_id=self.organization_id,
+                job_definition_name=self.job_definition_name,
+                filepaths=cast(List[str], source),
+                handler=handler,
+                image=image,
+                environment=environment,
+                description=description)
+            return JobDefinitionVersion.from_response(
+                api=self.__api,
+                organization_id=self.organization_id,
+                response=res,
+                job_definition=self.__job_definition)
 
     def update(self, job_definition_version: int, description: str) -> JobDefinitionVersion:
         """Update a training job definition version.

--- a/abeja/training/job_definition.py
+++ b/abeja/training/job_definition.py
@@ -558,6 +558,23 @@ class JobDefinitionVersions():
             response=res,
             job_definition=self.__job_definition)
 
+    def archive(self, job_definition_version: int):
+        """Archive a training job definition version.
+
+        Request Syntax:
+            .. code-block:: python
+
+                versions.archive(job_definition_version=5)
+
+            Params:
+            - **job_definition_version** (int): the version number
+        """
+        self.__api.archive_training_job_definition_version(
+            organization_id=self.organization_id,
+            job_definition_name=self.job_definition_name,
+            version_id=job_definition_version)
+
+
 # Iterator classes
 
 

--- a/abeja/training/job_definition.py
+++ b/abeja/training/job_definition.py
@@ -575,7 +575,7 @@ class JobDefinitionVersions():
             version_id=job_definition_version)
 
     def unarchive(self, job_definition_version: int):
-        """unarchive a training job definition version.
+        """Unarchive a training job definition version.
 
         Request Syntax:
             .. code-block:: python
@@ -586,6 +586,22 @@ class JobDefinitionVersions():
             - **job_definition_version** (int): the version number
         """
         self.__api.unarchive_training_job_definition_version(
+            organization_id=self.organization_id,
+            job_definition_name=self.job_definition_name,
+            version_id=job_definition_version)
+
+    def delete(self, job_definition_version: int):
+        """Delete a training job definition version.
+
+        Request Syntax:
+            .. code-block:: python
+
+                versions.delete(job_definition_version=5)
+
+            Params:
+            - **job_definition_version** (int): the version number
+        """
+        self.__api.delete_training_job_definition_version(
             organization_id=self.organization_id,
             job_definition_name=self.job_definition_name,
             version_id=job_definition_version)

--- a/abeja/training/job_definition.py
+++ b/abeja/training/job_definition.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict, List, Iterator, Optional
+from typing import cast, Any, Dict, List, Iterator, Optional, Union, IO, AnyStr
 from .api.client import APIClient
 from .common import SizedIterable
 
-
 # Entity classes
+
 
 class JobDefinition():
     """Training job definition object.
@@ -428,6 +428,57 @@ class JobDefinitionVersions():
             organization_id=self.organization_id,
             job_definition_name=self.job_definition_name,
             version_id=job_definition_version)
+
+        return JobDefinitionVersion.from_response(
+            api=self.__api,
+            organization_id=self.organization_id,
+            response=res,
+            job_definition=self.__job_definition)
+
+    def create(self,
+               source: Union[List[str], IO[AnyStr]],
+               handler: str,
+               image: Optional[str] = None,
+               environment: Optional[Dict[str, Any]] = None,
+               description: Optional[str] = None):
+        """Create a new training job definition version.
+
+        Request Syntax:
+            .. code-block:: python
+
+                version = versions.create(
+                    source=['train.py'],
+                    handler='train:handler',
+                    image='abeja-inc/all-gpu:19.04',
+                    environment={'key': 'value'},
+                    description='new version')
+
+            Params:
+            - **job_definition_version** (int): the version number
+            - **source** (List[str] | IO): an input source for training code. It's one of:
+              - zip or tar.gz archived file-like object.
+              - a list of file paths.
+            - **image** (Optional[str]): runtime environment
+            - **environment** (Optional[dict]): user defined parameters set as environment variables
+            - **description** (Optional[str]): description
+
+        Return type:
+            :class:`JobDefinitionVersion` object
+
+        """
+        parameters = {'handler': handler}  # type: Dict[str, Any]
+        if image is not None:
+            parameters['image'] = image
+        if environment is not None:
+            parameters['environment'] = environment
+        if description is not None:
+            parameters['description'] = description
+
+        res = self.__api.create_training_job_definition_version_native_api(
+            organization_id=self.organization_id,
+            job_definition_name=self.job_definition_name,
+            source_code=cast(IO[AnyStr], source),
+            parameters=parameters)
 
         return JobDefinitionVersion.from_response(
             api=self.__api,

--- a/tests/training/test_job_definition.py
+++ b/tests/training/test_job_definition.py
@@ -127,6 +127,7 @@ def test_archive_job_definition(requests_mock, api_base_url, api_client,
         json={'message': "test-1 archived"})
 
     adapter.archive(name=job_definition_id)
+    assert requests_mock.called
 
 
 def test_unarchive_job_definition(requests_mock, api_base_url, api_client,
@@ -138,6 +139,7 @@ def test_unarchive_job_definition(requests_mock, api_base_url, api_client,
         json={'message': "test-1 unarchived"})
 
     adapter.unarchive(name=job_definition_id)
+    assert requests_mock.called
 
 
 def test_delete_job_definition(requests_mock, api_base_url, api_client,
@@ -149,6 +151,7 @@ def test_delete_job_definition(requests_mock, api_base_url, api_client,
         json={'message': "test-1 deleted"})
 
     adapter.delete(name=job_definition_id)
+    assert requests_mock.called
 
 
 def test_list_job_definitions(requests_mock, api_base_url, api_client,
@@ -465,3 +468,17 @@ def test_update_job_definition_version(requests_mock, api_base_url,
     history = requests_mock.request_history
     assert len(history) == 1
     assert history[0].json() == {'description': description}
+
+
+def test_archive_job_definition_version(requests_mock, api_base_url, api_client,
+                                        job_definition_factory) -> None:
+    definition = job_definition_factory()  # type: JobDefinition
+    adapter = definition.job_definition_versions()
+
+    requests_mock.post(
+        '{}/organizations/{}/training/definitions/{}/versions/1/archive'.format(
+            api_base_url, adapter.organization_id, adapter.job_definition_name),
+        json={'message': "test-1 archived"})
+
+    adapter.archive(job_definition_version=1)
+    assert requests_mock.called

--- a/tests/training/test_job_definition.py
+++ b/tests/training/test_job_definition.py
@@ -482,3 +482,17 @@ def test_archive_job_definition_version(requests_mock, api_base_url, api_client,
 
     adapter.archive(job_definition_version=1)
     assert requests_mock.called
+
+
+def test_unarchive_job_definition_version(requests_mock, api_base_url, api_client,
+                                          job_definition_factory) -> None:
+    definition = job_definition_factory()  # type: JobDefinition
+    adapter = definition.job_definition_versions()
+
+    requests_mock.post(
+        '{}/organizations/{}/training/definitions/{}/versions/1/unarchive'.format(
+            api_base_url, adapter.organization_id, adapter.job_definition_name),
+        json={'message': "test-1 unarchived"})
+
+    adapter.unarchive(job_definition_version=1)
+    assert requests_mock.called

--- a/tests/training/test_job_definition.py
+++ b/tests/training/test_job_definition.py
@@ -289,3 +289,28 @@ def test_get_job_definition_version(requests_mock, api_base_url,
 
     assert version.job_definition
     assert version.job_definition_id == adapter.job_definition_id
+
+
+def test_update_job_definition_version(requests_mock, api_base_url,
+                                       job_definition_factory, training_job_definition_version_response) -> None:
+    definition = job_definition_factory()
+    adapter = definition.job_definition_versions()
+
+    res = training_job_definition_version_response(adapter.organization_id, adapter.job_definition_id)
+    version_id = res['job_definition_version']
+    requests_mock.patch(
+        '{}/organizations/{}/training/definitions/{}/versions/{}'.format(
+            api_base_url, adapter.organization_id, adapter.job_definition_name, version_id),
+        json=res)
+
+    description = 'new version'
+    version = adapter.update(job_definition_version=version_id, description=description)
+    assert version
+    assert version.job_definition_version == version_id
+
+    assert version.job_definition
+    assert version.job_definition_id == adapter.job_definition_id
+
+    history = requests_mock.request_history
+    assert len(history) == 1
+    assert history[0].json() == {'description': description}

--- a/tests/training/test_job_definition.py
+++ b/tests/training/test_job_definition.py
@@ -496,3 +496,17 @@ def test_unarchive_job_definition_version(requests_mock, api_base_url, api_clien
 
     adapter.unarchive(job_definition_version=1)
     assert requests_mock.called
+
+
+def test_delete_job_definition_version(requests_mock, api_base_url, api_client,
+                                       job_definition_factory) -> None:
+    definition = job_definition_factory()  # type: JobDefinition
+    adapter = definition.job_definition_versions()
+
+    requests_mock.delete(
+        '{}/organizations/{}/training/definitions/{}/versions/1'.format(
+            api_base_url, adapter.organization_id, adapter.job_definition_name),
+        json={'message': "test-1 deleted"})
+
+    adapter.delete(job_definition_version=1)
+    assert requests_mock.called

--- a/tests/training/test_job_definition.py
+++ b/tests/training/test_job_definition.py
@@ -320,8 +320,7 @@ def test_create_job_definition_version_zip(
     c_type, c_data = cgi.parse_header(history[0].headers['Content-Type'])
     assert c_type == 'multipart/form-data'
 
-    c_data['boundary'] = c_data['boundary'].encode()
-    form_data = cgi.parse_multipart(BytesIO(history[0].body), c_data)
+    form_data = cgi.parse_multipart(BytesIO(history[0].body), {'boundary': c_data['boundary'].encode()})
     parameters = json.loads(form_data['parameters'][0].decode('utf-8'))
 
     assert form_data['source_code'][0] == zip_content


### PR DESCRIPTION
https://github.com/abeja-inc/abeja-platform-sdk/pull/20 のつづきです。

Training Job Definition Version の操作を追加しています。また、APIClient にも足りないメソッドがいくつかあったので追加しました。