### PR TITLE
add py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ license = "Apache-2.0"
 packages = [
     { include = "abeja" }
 ]
+include = ["abeja/training/py.typed"]
 
 [tool.poetry.dependencies]
 python = "~=3.5"


### PR DESCRIPTION
SDK の `abeja.training` を my.py で型検査できるように `py.typed` を追加しました。
https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages
