### PR TITLE
support datasource basic auth

### DIFF
--- a/abeja/common/auth.py
+++ b/abeja/common/auth.py
@@ -17,8 +17,8 @@ def get_token_from_environment():
     }
 
 
-def get_basic_auth_from_environment():
-    """get abeja platform basic auth id and pass from environment variables
+def get_user_basic_auth_from_environment():
+    """get abeja platform user basic auth id and pass from environment variables
     basic auth id : user_id
     basic auth pass : personal access token of the user
 
@@ -39,6 +39,27 @@ def get_basic_auth_from_environment():
     }
 
 
+def get_datasource_basic_auth_from_environment():
+    """get abeja platform datasource basic auth id and pass from environment variables
+    basic auth id : datasource id
+    basic auth pass : datasource secret of the user
+
+    :return: dict
+    {
+        "datasource_id": ABEJA_PLATFORM_DATASOURCE_ID,
+        "datasource_secret": ABEJA_PLATFORM_DATASOURCE_SECRET
+    }
+    """
+    datasource_id = os.environ.get('ABEJA_PLATFORM_DATASOURCE_ID')
+    datasource_secret = os.environ.get('ABEJA_PLATFORM_DATASOURCE_SECRET')
+    if not datasource_id or not datasource_secret:
+        return None
+    return {
+        "datasource_id": datasource_id,
+        "datasource_secret": datasource_secret
+    }
+
+
 def get_credential():
     """get credential in the following priority
     1. jwt token in environment
@@ -46,5 +67,7 @@ def get_credential():
 
     :return: dict
     """
-    credential = get_token_from_environment() or get_basic_auth_from_environment()
+    credential = get_token_from_environment() \
+        or get_user_basic_auth_from_environment() \
+        or get_datasource_basic_auth_from_environment()
     return credential

--- a/abeja/common/connection.py
+++ b/abeja/common/connection.py
@@ -50,6 +50,10 @@ class Connection:
                 "user-"):
             self.credential['user_id'] = 'user-{}'.format(
                 self.credential['user_id'])
+        if 'datasource_id' in self.credential and \
+                not self.credential['datasource_id'].startswith('datasource-'):
+            self.credential['datasource_id'] = 'datasource-{}'.format(
+                self.credential['datasource_id'])
 
     def api_request(
             self,
@@ -147,6 +151,15 @@ class Connection:
             user_id = self.credential['user_id']
             personal_access_token = self.credential['personal_access_token']
             base = '{}:{}'.format(user_id, personal_access_token)
+            encoded = base64.b64encode(base.encode('utf-8'))
+            return {
+                'Authorization': 'Basic {}'.format(encoded.decode('utf-8'))
+            }
+        if self.credential.get('datasource_id') and self.credential.get(
+                'datasource_secret'):
+            datasource_id = self.credential['datasource_id']
+            datasource_secret = self.credential['datasource_secret']
+            base = '{}:{}'.format(datasource_id, datasource_secret)
             encoded = base64.b64encode(base.encode('utf-8'))
             return {
                 'Authorization': 'Basic {}'.format(encoded.decode('utf-8'))

--- a/tests/common/test_auth.py
+++ b/tests/common/test_auth.py
@@ -3,13 +3,16 @@ import unittest
 from unittest.mock import patch
 from abeja.common.auth import (
     get_token_from_environment,
-    get_basic_auth_from_environment,
+    get_user_basic_auth_from_environment,
+    get_datasource_basic_auth_from_environment,
     get_credential
 )
 
 TEST_TOKEN = 'test_token'
 TEST_USER_ID = 'test_user_id'
 TEST_PERSONAL_ACCESS_TOKEN = 'test_personal_access_token'
+TEST_DATASOURCE_ID = 'test_datasource_id'
+TEST_DATASOURCE_SECRET = 'test_datasource_secret'
 
 
 class TestAuth(unittest.TestCase):
@@ -24,16 +27,32 @@ class TestAuth(unittest.TestCase):
         'ABEJA_PLATFORM_USER_ID': TEST_USER_ID,
         'ABEJA_PLATFORM_PERSONAL_ACCESS_TOKEN': TEST_PERSONAL_ACCESS_TOKEN
     })
-    def test_get_basic_auth_from_environment(self):
-        token = get_basic_auth_from_environment()
+    def test_get_user_basic_auth_from_environment(self):
+        token = get_user_basic_auth_from_environment()
         self.assertDictEqual(token, {
             'user_id': TEST_USER_ID,
             'personal_access_token': TEST_PERSONAL_ACCESS_TOKEN
         })
 
     @patch.dict(os.environ, {'ABEJA_PLATFORM_USER_ID': TEST_USER_ID})
-    def test_get_basic_auth_from_environment_with_only_user_id(self):
-        token = get_basic_auth_from_environment()
+    def test_get_user_basic_auth_from_environment_with_only_user_id(self):
+        token = get_user_basic_auth_from_environment()
+        self.assertIsNone(token)
+
+    @patch.dict(os.environ, {
+        'ABEJA_PLATFORM_DATASOURCE_ID': TEST_DATASOURCE_ID,
+        'ABEJA_PLATFORM_DATASOURCE_SECRET': TEST_DATASOURCE_SECRET
+    })
+    def test_get_datasource_basic_auth_from_environment(self):
+        token = get_datasource_basic_auth_from_environment()
+        self.assertDictEqual(token, {
+            'datasource_id': TEST_DATASOURCE_ID,
+            'datasource_secret': TEST_DATASOURCE_SECRET
+        })
+
+    @patch.dict(os.environ, {'ABEJA_PLATFORM_DATASOURCE_ID': TEST_DATASOURCE_ID})
+    def test_get_datasource_basic_auth_from_environment_with_only_datasource_id(self):
+        token = get_datasource_basic_auth_from_environment()
         self.assertIsNone(token)
 
     @patch.dict(os.environ, {'PLATFORM_AUTH_TOKEN': TEST_TOKEN})
@@ -52,6 +71,17 @@ class TestAuth(unittest.TestCase):
         self.assertDictEqual(token, {
             'user_id': TEST_USER_ID,
             'personal_access_token': TEST_PERSONAL_ACCESS_TOKEN
+        })
+
+    @patch.dict(os.environ, {
+        'ABEJA_PLATFORM_DATASOURCE_ID': TEST_DATASOURCE_ID,
+        'ABEJA_PLATFORM_DATASOURCE_SECRET': TEST_DATASOURCE_SECRET
+    })
+    def test_get_credential_with_datasource_id_and_secret(self):
+        token = get_credential()
+        self.assertDictEqual(token, {
+            'datasource_id': TEST_DATASOURCE_ID,
+            'datasource_secret': TEST_DATASOURCE_SECRET
         })
 
     @patch.dict(os.environ, {})


### PR DESCRIPTION
datasouce_auth を追加しました．以下のようなスクリプトで動作することを確認済です．

```python
credential = {'datasource_id': datasource_id, 'datasource_secret': datasource_secret}
channel = Channel(api=APIClient(credential=credential), organization_id=None, channel_id=channel_id)
channel.upload_file('test.jpg', content_type='image/jpeg')
```

なお，`Client.get_channel` をしていないのは，datasource の認証だとそこの認証が通らない想定のためです．