### PR TITLE
add export_log option to Jobs.create

### DIFF
--- a/abeja/training/api/client.py
+++ b/abeja/training/api/client.py
@@ -766,7 +766,8 @@ class APIClient(BaseAPIClient):
             datasets: Optional[dict] = None,
             instance_type: Optional[str] = None,
             environment: Optional[dict] = None,
-            description: Optional[str] = None) -> dict:
+            description: Optional[str] = None,
+            export_log: Optional[bool] = None) -> dict:
         """create a training job
 
         API reference: POST /organizations/<organization_id>/training/definitions/<job_definition_name>/versions/<version_id>/jobs
@@ -795,6 +796,8 @@ class APIClient(BaseAPIClient):
             - **instance_type** (str): **[optional]** instance type of running environment
             - **environment** (dict): **[optional]** user defined parameters set as environment variables
             - **description** (str): **[optional]** description of this job
+            - **export_log** (bool): **[optional]** If ``true``, include the log in the model.
+              This feature is only available with 19.04 or later images.  (default: ``false``)
 
         Return type:
             dict
@@ -854,6 +857,8 @@ class APIClient(BaseAPIClient):
                     status_code=400)
         if description is not None:
             data['description'] = description
+        if export_log is not None:
+            data['export_log'] = export_log
         path = '/organizations/{}/training/definitions/{}/versions/{}/jobs'.format(
             organization_id, job_definition_name, version_id)
         return self._connection.api_request(

--- a/abeja/training/job.py
+++ b/abeja/training/job.py
@@ -313,7 +313,8 @@ class Jobs():
                instance_type: InstanceType,
                datasets: Optional[Dict[str, str]] = None,
                environment: Optional[Dict[str, Any]] = None,
-               description: Optional[str] = None) -> Job:
+               description: Optional[str] = None,
+               export_log: Optional[bool] = None) -> Job:
         """Create a new training job.
 
         Request Syntax:
@@ -329,6 +330,8 @@ class Jobs():
             - **datasets** (dict): **[optional]** datasets, combination of alias and dataset_id
             - **environment** (dict): **[optional]** user defined parameters set as environment variables
             - **description** (str): **[optional]** description of this job
+            - **export_log** (bool): **[optional]** If ``true``, include the log in the model.
+              This feature is only available with 19.04 or later images.  (default: ``false``)
 
         Return type:
             :class:`Job` object
@@ -340,7 +343,9 @@ class Jobs():
             datasets=datasets,
             instance_type=str(instance_type),
             environment=environment,
-            description=description)
+            description=description,
+            export_log=export_log
+        )
 
         return Job.from_response(
             api=self.__api,

--- a/tests/training/api/test_client.py
+++ b/tests/training/api/test_client.py
@@ -314,11 +314,12 @@ class TestApiClient:
 
     @patch('requests.Session.request')
     @pytest.mark.parametrize(
-        'user_params,environment,datasets,instance_type,description,expected',
+        'user_params,environment,datasets,instance_type,description,export_log,expected',
         [
-            (None, None, None, None, None, {}),
+            (None, None, None, None, None, None, {}),
             (
                 {'DUMMY_ENV_VAR': 'dummy'},
+                None,
                 None,
                 None,
                 None,
@@ -328,6 +329,7 @@ class TestApiClient:
             (
                 None,
                 {'DUMMY_ENV_VAR': 'dummy'},
+                None,
                 None,
                 None,
                 None,
@@ -339,12 +341,14 @@ class TestApiClient:
                 None,
                 None,
                 None,
+                None,
                 {'environment': {'DUMMY_ENV_VAR': 'dummy2'}}
             ),
             (
                 None,
                 None,
                 {"mnist": "1111111111111"},
+                None,
                 None,
                 None,
                 {'datasets': {"mnist": "1111111111111"}}
@@ -355,6 +359,7 @@ class TestApiClient:
                 None,
                 'cpu-1',
                 None,
+                None,
                 {'instance_type': 'cpu-1'}
             ),
             (
@@ -363,12 +368,22 @@ class TestApiClient:
                 {"mnist": "1111111111111"},
                 'cpu-1',
                 'dummy description',
+                None,
                 {
                     'datasets': {"mnist": "1111111111111"},
                     'environment': {'DUMMY_ENV_VAR': 'dummy'},
                     'instance_type': 'cpu-1',
                     'description': 'dummy description'
                 }
+            ),
+            (
+                None,
+                None,
+                None,
+                None,
+                None,
+                True,
+                {'export_log': True}
             ),
         ]
     )
@@ -380,10 +395,18 @@ class TestApiClient:
             datasets,
             instance_type,
             description,
+            export_log,
             expected):
         self.api_client.create_training_job(
-            ORGANIZATION_ID, JOB_DEFINITION_NAME, VERSION_ID,
-            user_params, datasets, instance_type, environment, description)
+            ORGANIZATION_ID,
+            JOB_DEFINITION_NAME,
+            VERSION_ID,
+            user_params,
+            datasets,
+            instance_type,
+            environment,
+            description,
+            export_log)
         url = '{}/organizations/{}/training/definitions/{}/versions/{}/jobs'.format(
             ABEJA_API_URL, ORGANIZATION_ID, JOB_DEFINITION_NAME, VERSION_ID)
         m.assert_called_once_with(


### PR DESCRIPTION
https://github.com/abeja-inc/platform-planning/issues/3475

`{"export_log": true}` と送ると、19.04 以降のイメージを使っていれば、[.abeja_train.log という名前のログファイルを artifact に含めるようになります](https://github.com/abeja-inc/platform-model-proxy/pull/59)。