### PR TITLE
Feature/support nan in metrics

### DIFF
--- a/abeja/tracking/metric.py
+++ b/abeja/tracking/metric.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import math
 from typing import Union
 
 
@@ -24,12 +25,15 @@ class Metric:
     class SpecialValues(Enum):
         INFINITY = "Infinity"
         MINUS_INFINITY = "-Infinity"
+        NAN = "NaN"
 
     def __format_value(self) -> Union[float, str]:
         if self.value == float('inf'):
             return Metric.SpecialValues.INFINITY.value
         elif self.value == float('-inf'):
             return Metric.SpecialValues.MINUS_INFINITY.value
+        elif math.isnan(self.value):
+            return Metric.SpecialValues.NAN.value
         return self.value
 
     def to_dict(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,8 +223,7 @@ def user_response(user_id):
                 "thumbnail_icon_url": "https://icon.example.com/users/{}".format(user_id),
                 "original_icon_url": "https://icon.example.com/users/{}".format(user_id),
                 "mini_icon_url": "https://icon.example.com/users/{}".format(user_id),
-            }
-        }
+            }}
     return _response
 
 
@@ -298,7 +297,10 @@ def delete_file_response():
 
 
 @pytest.fixture
-def job_definition_response(organization_id, job_definition_id, job_definition_name):
+def job_definition_response(
+        organization_id,
+        job_definition_id,
+        job_definition_name):
     def _training_job_definition_response(
             organization_id=organization_id,
             training_job_definition_id=job_definition_id,
@@ -431,7 +433,11 @@ def job_result_response():
 
 
 @pytest.fixture
-def training_model_response(job_definition_id, job_id, training_model_id, user_response):
+def training_model_response(
+        job_definition_id,
+        job_id,
+        training_model_id,
+        user_response):
     def _response(**extra):
         return {
             'user_parameters': {},
@@ -498,9 +504,18 @@ def deployment_version_response(deployment_id, deployment_version_id):
 
 
 @pytest.fixture
-def create_service_response(service_id, deployment_id, deployment_version_id, job_definition_id,
-                            training_model_id, training_model_version_id, user_response):
-    def _response(training_model_id=training_model_id, job_definition_id=job_definition_id, **extra):
+def create_service_response(
+        service_id,
+        deployment_id,
+        deployment_version_id,
+        job_definition_id,
+        training_model_id,
+        training_model_version_id,
+        user_response):
+    def _response(
+            training_model_id=training_model_id,
+            job_definition_id=job_definition_id,
+            **extra):
         return {
             'user_env_vars': {},
             'status': 'IN_PROGRESS',

--- a/tests/datasets/test_dataset_item.py
+++ b/tests/datasets/test_dataset_item.py
@@ -12,9 +12,7 @@ DATASET_ITEM_SOURCE_DATA_DATALAKE = [
         'data_type': 'image/jpeg',
         'data_uri': 'datalake://1200123803688/20170815T044617-f20dde80-1e3b-4496-bc06-1b63b026b872',
         'height': 500,
-        'width': 200
-    }
-]
+        'width': 200}]
 DATASET_ITEM_SOURCE_DATA_HTTP = [
     {
         "data_uri": "http://example.com/hoge/foo/bar.jpg",
@@ -91,21 +89,12 @@ class TestDatasetItem(unittest.TestCase):
         self.assertEqual(item.created_at, self.created_at)
         self.assertEqual(item.updated_at, self.updated_at)
 
-    @parameterized.expand([
-        (
-            DATASET_ITEM_SOURCE_DATA_DATALAKE,
-            [
-                {
-                    "data_type": "image/jpeg",
-                    "data_uri": "datalake://1200123803688/20170815T044617-f20dde80-1e3b-4496-bc06-1b63b026b872",
-                }
-            ]
-        ),
-        (
-            DATASET_ITEM_SOURCE_DATA_HTTP,
-            DATASET_ITEM_SOURCE_DATA_HTTP
-        )
-    ])
+    @parameterized.expand([(DATASET_ITEM_SOURCE_DATA_DATALAKE,
+                            [{"data_type": "image/jpeg",
+                              "data_uri": "datalake://1200123803688/20170815T044617-f20dde80-1e3b-4496-bc06-1b63b026b872",
+                              }]),
+                           (DATASET_ITEM_SOURCE_DATA_HTTP,
+                            DATASET_ITEM_SOURCE_DATA_HTTP)])
     def test_asdict(self, source_data, expected_source_data):
         item = DatasetItem(None, self.organization_id,
                            self.dataset_id, self.item_id,

--- a/tests/tracking/test_metric.py
+++ b/tests/tracking/test_metric.py
@@ -26,6 +26,7 @@ class TestMetric:
             (('xxx', 123), {'xxx': 123}),
             (('main/acc', float('inf')), {'main_acc': 'Infinity'}),
             (('xxx', float('-inf')), {'xxx': '-Infinity'}),
+            (('main/acc', float('nan')), {'main_acc': 'NaN'}),
         ]
     )
     def test_to_dict(self, given, expected):

--- a/tests/training/test_model.py
+++ b/tests/training/test_model.py
@@ -6,15 +6,24 @@ from abeja.common import exec_env
 from abeja.training import JobDefinition  # noqa: F401
 
 
-def test_model_from_response(training_api_client, organization_id, training_model_response):
+def test_model_from_response(
+        training_api_client,
+        organization_id,
+        training_model_response):
     response = training_model_response()
     model = Model.from_response(training_api_client, organization_id, response)
     assert model
 
 
-def test_model_get_job_without_job(requests_mock, api_base_url, training_api_client,
-                                   organization_id, job_definition_id, job_definition_name,
-                                   training_model_response, job_definition_response):
+def test_model_get_job_without_job(
+        requests_mock,
+        api_base_url,
+        training_api_client,
+        organization_id,
+        job_definition_id,
+        job_definition_name,
+        training_model_response,
+        job_definition_response):
     requests_mock.get(
         '{}/organizations/{}/training/definitions/{}'.format(
             api_base_url,
@@ -29,9 +38,17 @@ def test_model_get_job_without_job(requests_mock, api_base_url, training_api_cli
     assert model.job is None
 
 
-def test_model_get_job(requests_mock, api_base_url, training_api_client,
-                       organization_id, job_definition_id, job_definition_name, job_id,
-                       training_model_response, job_definition_response, job_response):
+def test_model_get_job(
+        requests_mock,
+        api_base_url,
+        training_api_client,
+        organization_id,
+        job_definition_id,
+        job_definition_name,
+        job_id,
+        training_model_response,
+        job_definition_response,
+        job_response):
     requests_mock.get(
         '{}/organizations/{}/training/definitions/{}'.format(
             api_base_url,
@@ -216,8 +233,11 @@ def test_update_model(requests_mock, api_base_url,
     assert model.description == description
 
 
-def test_get_download_uri(requests_mock, api_base_url,
-                          job_definition_factory, training_model_response) -> None:
+def test_get_download_uri(
+        requests_mock,
+        api_base_url,
+        job_definition_factory,
+        training_model_response) -> None:
     definition = job_definition_factory()  # type: JobDefinition
     adapter = definition.models()
 
@@ -235,8 +255,11 @@ def test_get_download_uri(requests_mock, api_base_url,
     assert adapter.get_download_uri(training_model_id) == uri
 
 
-def test_models_archive(requests_mock, api_base_url,
-                        job_definition_factory, training_model_response) -> None:
+def test_models_archive(
+        requests_mock,
+        api_base_url,
+        job_definition_factory,
+        training_model_response) -> None:
     definition = job_definition_factory()  # type: JobDefinition
     adapter = definition.models()
 
@@ -255,8 +278,11 @@ def test_models_archive(requests_mock, api_base_url,
     assert requests_mock.called
 
 
-def test_models_unarchive(requests_mock, api_base_url,
-                          job_definition_factory, training_model_response) -> None:
+def test_models_unarchive(
+        requests_mock,
+        api_base_url,
+        job_definition_factory,
+        training_model_response) -> None:
     definition = job_definition_factory()  # type: JobDefinition
     adapter = definition.models()
 


### PR DESCRIPTION
cf. https://github.com/abeja-inc/model_api/pull/1021

- metrics に nan が含まれている場合には文字列の NaN として送信する
