### PR TITLE
Add doc of datalake channels

### DIFF
--- a/doc/source/datalake/apis/client.rst
+++ b/doc/source/datalake/apis/client.rst
@@ -14,6 +14,13 @@ Channel
    :members:
    :undoc-members:
 
+Channels
+--------
+
+.. autoclass:: abeja.datalake.channel.Channels
+   :members:
+   :undoc-members:
+
 File
 -----
 


### PR DESCRIPTION
Datalake Channels をドキュメントに追加しました。

```
>?SDKドキュメントのDatalakeのClientにcreate()の記載がないのですが、これは意図的でしょうか？
?（いまcreateの仕様が知りたくて見に行ったらみつからなく）

https://sdk-spec.abeja.io/datalake/apis/client.html

Client のリファレンスから Channels へのリンクがほしい
```
--- 

**Channels の追加**

![image](https://user-images.githubusercontent.com/1647045/92702263-f2ef6380-f38b-11ea-9449-ed0227a63106.png)

---

**Channels への遷移が可能になった**
![image](https://user-images.githubusercontent.com/1647045/92702219-e703a180-f38b-11ea-9a22-018f0d8b5fe0.png)
