### PR TITLE
add low-level API `abeja.services.APIClient.request_service`

### DIFF
--- a/abeja/common/connection.py
+++ b/abeja/common/connection.py
@@ -2,7 +2,7 @@ import base64
 import json
 import os
 import http
-from typing import Optional
+from typing import Optional, Union, Text, IO, MutableMapping, Any
 from urllib.parse import urlparse
 
 from requests import Session
@@ -96,10 +96,10 @@ class Connection:
             self,
             subdomain: str,
             path: str,
-            data=None,
-            json=None,
-            headers=None,
-            params=None,
+            data: Union[None, Text, bytes, IO]=None,
+            json: Optional[Any]=None,
+            headers: Optional[MutableMapping[Text, Text]]=None,
+            params: Union[None, bytes, MutableMapping[Text, Text]]=None,
             **kwargs):
         """call service api and handle errors if needed
 

--- a/abeja/common/connection.py
+++ b/abeja/common/connection.py
@@ -3,6 +3,7 @@ import json
 import os
 import http
 from typing import Optional
+from urllib.parse import urlparse
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -88,6 +89,45 @@ class Connection:
                                params=params,
                                **kwargs)
             return res.json()
+        except RequestsHTTPError as e:
+            http_error_handler(e)
+
+    def service_request(
+            self,
+            subdomain: str,
+            path: str,
+            data=None,
+            json=None,
+            headers=None,
+            params=None,
+            **kwargs):
+        """call service api and handle errors if needed
+
+        :param subdomain:
+        :param path:
+        :param data:
+        :param json:
+        :param headers:
+        :param params:
+        :param kwargs:
+        :return: (requests.Response)
+        """
+        if headers is None:
+            headers = {}
+        headers.update(self._set_user_agent())
+        headers.update(self._get_auth_header())
+
+        base = urlparse(self.BASE_URL)
+        target_url = '{}://{}.{}{}'.format(base.scheme, subdomain, base.netloc, path)
+        try:
+            return self.request(
+                method='POST',
+                url=target_url,
+                data=data,
+                json=json,
+                headers=headers,
+                params=params,
+                **kwargs)
         except RequestsHTTPError as e:
             http_error_handler(e)
 

--- a/abeja/services/api/client.py
+++ b/abeja/services/api/client.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, Optional, IO, Text, Union, Any
 
 import requests
 
@@ -504,8 +504,8 @@ class APIClient(BaseAPIClient):
             organization_id: str,
             deployment_id: str,
             service_id: str,
-            data: Optional[bytes]=None,
-            json: Optional[dict]=None,
+            data: Union[None, Text, bytes, IO]=None,
+            json: Optional[Any]=None,
             content_type: Optional[str]=None) -> requests.Response:
         """post request to the service
 
@@ -527,16 +527,15 @@ class APIClient(BaseAPIClient):
 
                 # send image data
                 with open('./foo.png', 'rb') as f:
-                    data = f.read()
-                response = api_client.request_service(organization_id, deployment_id, service_id, data=data, content_type='image/png')
+                    response = api_client.request_service(organization_id, deployment_id, service_id, data=f, content_type='image/png')
 
         Params:
             - **organization_id** (str): organization_id
             - **deployment_id** (str): deployment identifier
             - **service_id** (str): service identifier
-            - **data** (bytes): binary type request payload
-            - **json** (dict): json type request payload
-            - **content_type** (string): MIME-Type. Specify if you want to send binary data using `data` to the service
+            - **data** (bytes): a request payload of something other than json **[optional]**
+            - **json** (dict): a request payload of json **[optional]**
+            - **content_type** (string): MIME-Type. Specify if you want to send data using `data` to the service **[optional]**
 
         Return type:
             requests.Response

--- a/abeja/services/api/client.py
+++ b/abeja/services/api/client.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Dict, Optional
 
+import requests
+
 from abeja.common.api_client import BaseAPIClient
 
 
@@ -496,3 +498,60 @@ class APIClient(BaseAPIClient):
             organization_id, deployment_id, service_id)
         return self._connection.api_request(
             method='GET', path=path, params=params)
+
+    def request_service(
+            self,
+            organization_id: str,
+            deployment_id: str,
+            service_id: str,
+            data: Optional[bytes]=None,
+            json: Optional[dict]=None,
+            content_type: Optional[str]=None) -> requests.Response:
+        """post request to the service
+
+        API reference: POST https://<organization_id>.api.abeja.io/deployments/<deployment_id>/services/<service_id>
+
+        Request Syntax:
+            .. code-block:: python
+
+                organization_id = "1234567890123"
+                deployment_id = "1111111111111"
+                service_id = "ser-3333333333333333"
+
+                # send json data
+                json_data = {
+                    "foo": "bar",
+                    "baz": "qux"
+                }
+                response = api_client.request_service(organization_id, deployment_id, service_id, json=json_data)
+
+                # send image data
+                with open('./foo.png', 'rb') as f:
+                    data = f.read()
+                response = api_client.request_service(organization_id, deployment_id, service_id, data=data, content_type='image/png')
+
+        Params:
+            - **organization_id** (str): organization_id
+            - **deployment_id** (str): deployment identifier
+            - **service_id** (str): service identifier
+            - **data** (bytes): binary type request payload
+            - **json** (dict): json type request payload
+            - **content_type** (string): MIME-Type. Specify if you want to send binary data using `data` to the service
+
+        Return type:
+            requests.Response
+
+        Raises:
+            - Unauthorized: Authentication failed
+            - NotFound:
+            - Forbidden:
+            - InternalServerError:
+        """
+        headers = {}
+        if content_type is not None:
+            headers['Content-Type'] = content_type
+        elif data is not None:
+            headers['Content-Type'] = 'application/octet-stream'
+        path = '/deployments/{}/services/{}'.format(deployment_id, service_id)
+        return self._connection.service_request(
+            subdomain=organization_id, path=path, headers=headers, data=data, json=json)

--- a/abeja/services/api/client.py
+++ b/abeja/services/api/client.py
@@ -533,9 +533,9 @@ class APIClient(BaseAPIClient):
             - **organization_id** (str): organization_id
             - **deployment_id** (str): deployment identifier
             - **service_id** (str): service identifier
-            - **data** (bytes): a request payload of something other than json **[optional]**
-            - **json** (dict): a request payload of json **[optional]**
-            - **content_type** (string): MIME-Type. Specify if you want to send data using `data` to the service **[optional]**
+            - **data** (Union[str, bytes, typing.IO]): **[optional]** a request payload of something other than json
+            - **json** (typing.Any): **[optional]** a request payload of json
+            - **content_type** (str): **[optional]** MIME-Type. Specify if you want to send data using `data` to the service
 
         Return type:
             requests.Response

--- a/doc/source/services/index.rst
+++ b/doc/source/services/index.rst
@@ -52,3 +52,5 @@ API Mapping
 +----------+------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------+
 | POST     | /organizations/<organization_id>/deployments/<deployment_id>/services/<service_id>/start | :meth:`APIClient.start_service() <abeja.services.APIClient.start_service>`       |
 +----------+------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------+
+| POST     | https://<organization_id>.api.abeja.io/deployments/<deployment_id>/services/<service_id> | :meth:`APIClient.request_service() <abeja.services.APIClient.request_service>`   |
++----------+------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------+

--- a/tests/services/api/test_client.py
+++ b/tests/services/api/test_client.py
@@ -1,9 +1,14 @@
+import json
 import unittest
 
 import requests_mock
 
+from abeja.common.connection import Connection
 from abeja.services import APIClient
 
+
+ABEJA_API_NETLOC = 'localhost:8080'
+ABEJA_API_URL = 'http://{}'.format(ABEJA_API_NETLOC)
 
 ORGANIZATION_ID = '1111111111111'
 SERVICE_ID = '2222222222222'
@@ -172,3 +177,62 @@ class TestAPIClient(unittest.TestCase):
             service_id=SERVICE_ID
         )
         self.assertDictEqual(res, SERVICE_RECENT_LOG_RES)
+
+    @requests_mock.Mocker()
+    def test_request_service_with_json_data(self, m):
+        request_json = {'foo': 'bar'}
+
+        def match_request(request):
+            content_type = request._request.headers.get('Content-Type', "")
+            if content_type != 'application/json':
+                return False
+            body = request._request.body.decode()
+            if json.dumps(request_json) != body:
+                return False
+            return True
+
+        url = 'http://{}.{}/deployments/{}/services/{}'.format(
+            ORGANIZATION_ID, ABEJA_API_NETLOC, DEPLOYMENT_ID, SERVICE_ID)
+        message_res = {
+            "message": "ok"
+        }
+        m.post(url, additional_matcher=match_request, json=message_res)
+
+        Connection.BASE_URL = ABEJA_API_URL
+        client = APIClient()
+        ret = client.request_service(
+            organization_id=ORGANIZATION_ID,
+            deployment_id=DEPLOYMENT_ID,
+            service_id=SERVICE_ID,
+            json=request_json)
+        self.assertEqual(ret.json(), message_res)
+
+    @requests_mock.Mocker()
+    def test_request_service_with_binary_data(self, m):
+        request_binary = b'binary data'
+
+        def match_request(request):
+            content_type = request._request.headers.get('Content-Type', "")
+            if content_type != 'image/png':
+                return False
+            body = request._request.body
+            if request_binary != body:
+                return False
+            return True
+
+        url = 'http://{}.{}/deployments/{}/services/{}'.format(
+            ORGANIZATION_ID, ABEJA_API_NETLOC, DEPLOYMENT_ID, SERVICE_ID)
+        message_res = {
+            "message": "ok"
+        }
+        m.post(url, additional_matcher=match_request, json=message_res)
+
+        Connection.BASE_URL = ABEJA_API_URL
+        client = APIClient()
+        ret = client.request_service(
+            organization_id=ORGANIZATION_ID,
+            deployment_id=DEPLOYMENT_ID,
+            service_id=SERVICE_ID,
+            data=request_binary,
+            content_type='image/png')
+        self.assertEqual(ret.json(), message_res)


### PR DESCRIPTION
> せっかく SDK を使っているので、Service にリクエストを送るときだけ requests を使いたくない。せめて JSON を送るインタンフェースが APIClient にほしい

こんな仕様でいかがでしょ？