### PR TITLE
add job_id to training.Models.create

### DIFF
--- a/abeja/training/model.py
+++ b/abeja/training/model.py
@@ -234,6 +234,7 @@ class Models():
 
     def create(self,
                model_data: IO[AnyStr],
+               job_id: Optional[str] = None,
                environment: Optional[Dict[str, Any]] = None,
                metrics: Optional[Dict[str, Any]] = None,
                description: Optional[str] = None) -> Model:
@@ -249,6 +250,7 @@ class Models():
 
         Params:
             - **model_data** (IO): An input source for ML model. It must be a zip archived file like object
+            - **job_id** (str): **[optional]** job identifer
             - **environment** (dict): **[optional]** user defined parameters set as environment variables
             - **metrics** (dict): **[optional]** user defined metrics for this model
             - **description** (str): **[optional]** description
@@ -258,6 +260,8 @@ class Models():
         """
         parameters = {}  # type: Dict[str, Any]
 
+        if job_id is not None:
+            parameters['training_job_id'] = job_id
         if environment is not None:
             parameters['user_parameters'] = environment
         if metrics is not None:

--- a/tests/training/test_model.py
+++ b/tests/training/test_model.py
@@ -178,11 +178,13 @@ def test_create_model(
 
     file_content = make_random_file_content()
     model_data = BytesIO(file_content)
+    job_id = '1'
     environment = {'BATCH_SIZE': 32, 'EPOCHS': 50}
     metrics = {'acc': 0.76, 'loss': 1.99}
 
     model = adapter.create(
         model_data,
+        job_id=job_id,
         environment=environment,
         metrics=metrics)
 


### PR DESCRIPTION
ABEJA Platform 上から `training.Models.create` が呼ばれることを想定して，`training_job_id` を optional で追加しました．