### PR TITLE
fix convert_to_zipfile_object

### DIFF
--- a/abeja/common/file_helpers.py
+++ b/abeja/common/file_helpers.py
@@ -36,7 +36,9 @@ def generate_path_iter(path: str, **kwargs) -> Iterable[str]:
 
 
 def convert_to_zipfile_object(fileobj: IO):
-    if zipfile.is_zipfile(fileobj):
+    is_zipfile = zipfile.is_zipfile(fileobj)
+    fileobj.seek(0)
+    if is_zipfile:
         return fileobj
     if hasattr(fileobj, "name"):
         named_fileobj = fileobj


### PR DESCRIPTION
`zipfile.is_zipfile` はファイルポインタを進めてしまうようなので修正しました．

```python
>>> data = open('hoge.zip', 'rb')
>>> data
<_io.BufferedReader name='hoge.zip'>
>>> data.read()
b'PK\x03\x04\x14\x00\x00\x00\x00\x00\x8f\x99<Q\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00 \x00hoge/UT\r\x00\x07\x0f\xb7q_5\xb7q_\x0f\xb7q_ux\x0b\x00\x01\x04\xe8\x03\x00\x00\x04\xe8\x03\x00\x00PK\x03\x04\x14\x00\x08\x00\x08\x00\x8f\x99<Q\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\t\x00 \x00hoge/testUT\r\x00\x07\x0e\xb7q_5\xb7q_\x0e\xb7q_ux\x0b\x00\x01\x04\xe8\x03\x00\x00\x04\xe8\x03\x00\x00+I-.\xe1\x02\x00PK\x07\x08\xc65\xb9;\x07\x00\x00\x00\x05\x00\x00\x00PK\x01\x02\x14\x03\x14\x00\x00\x00\x00\x00\x8f\x99<Q\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\xfdA\x00\x00\x00\x00hoge/UT\r\x00\x07\x0f\xb7q_5\xb7q_\x0f\xb7q_ux\x0b\x00\x01\x04\xe8\x03\x00\x00\x04\xe8\x03\x00\x00PK\x01\x02\x14\x03\x14\x00\x08\x00\x08\x00\x8f\x99<Q\xc65\xb9;\x07\x00\x00\x00\x05\x00\x00\x00\t\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\xa4\x81C\x00\x00\x00hoge/testUT\r\x00\x07\x0e\xb7q_5\xb7q_\x0e\xb7q_ux\x0b\x00\x01\x04\xe8\x03\x00\x00\x04\xe8\x03\x00\x00PK\x05\x06\x00\x00\x00\x00\x02\x00\x02\x00\xaa\x00\x00\x00\xa1\x00\x00\x00\x00\x00'
>>> data.seek(0)
0
>>> zipfile.is_zipfile(data)
True
>>> data.read()
b'PK\x05\x06\x00\x00\x00\x00\x02\x00\x02\x00\xaa\x00\x00\x00\xa1\x00\x00\x00\x00\x00'
```