### PR TITLE
Handle "Stale file handle" error

### DIFF
--- a/abeja/common/local_file.py
+++ b/abeja/common/local_file.py
@@ -154,34 +154,22 @@ def _read_file(path, file_type):
         except OSError as exc:
             # The file is already deleted in the NFS server (EFS), try to re-open it and read.
             if exc.errno == errno.ESTALE:
-                with open(path, mode) as f:
-                    return f.read()
+                with open(path, mode) as f2:
+                    return f2.read()
 
 
 def _read_iter_content_file(path, chunk_size):
+    # We can't handle "Stale file handle" error for this case.
     with open(path, 'rb') as f:
-        try:
-            for chunk in _read_in_chunks(f, chunk_size):
-                yield chunk
-        except OSError as exc:
-            # The file is already deleted in the NFS server (EFS), try to re-open it and read.
-            if exc.errno == errno.ESTALE:
-                with open(path, 'rb') as f:
-                    for chunk in _read_in_chunks(f, chunk_size):
-                        yield chunk
+        for chunk in _read_in_chunks(f, chunk_size):
+            yield chunk
 
 
 def _read_iter_lines_file(path):
+    # We can't handle "Stale file handle" error for this case.
     with open(path, 'r') as f:
-        try:
-            for line in f:
-                yield line
-        except OSError as exc:
-            # The file is already deleted in the NFS server (EFS), try to re-open it and read.
-            if exc.errno == errno.ESTALE:
-                with open(path, 'r') as f:
-                    for line in f:
-                        yield line
+        for line in f:
+            yield line
 
 
 def _write_file(path, file_type, content):

--- a/abeja/common/local_file.py
+++ b/abeja/common/local_file.py
@@ -154,20 +154,34 @@ def _read_file(path, file_type):
         except OSError as exc:
             # The file is already deleted in the NFS server (EFS), try to re-open it and read.
             if exc.errno == errno.ESTALE:
-                with open(path, mode) as f2:
-                    return f2.read()
+                with open(path, mode) as f:
+                    return f.read()
 
 
 def _read_iter_content_file(path, chunk_size):
     with open(path, 'rb') as f:
-        for chunk in _read_in_chunks(f, chunk_size):
-            yield chunk
+        try:
+            for chunk in _read_in_chunks(f, chunk_size):
+                yield chunk
+        except OSError as exc:
+            # The file is already deleted in the NFS server (EFS), try to re-open it and read.
+            if exc.errno == errno.ESTALE:
+                with open(path, 'rb') as f:
+                    for chunk in _read_in_chunks(f, chunk_size):
+                        yield chunk
 
 
 def _read_iter_lines_file(path):
     with open(path, 'r') as f:
-        for line in f:
-            yield line
+        try:
+            for line in f:
+                yield line
+        except OSError as exc:
+            # The file is already deleted in the NFS server (EFS), try to re-open it and read.
+            if exc.errno == errno.ESTALE:
+                with open(path, 'r') as f:
+                    for line in f:
+                        yield line
 
 
 def _write_file(path, file_type, content):

--- a/abeja/common/local_file.py
+++ b/abeja/common/local_file.py
@@ -10,6 +10,7 @@ local file is saved in MOUNT_DIR and follows the rules below.
 | http       | domain:port | path                    |
 
 """
+import errno
 import os
 import os.path
 from functools import wraps
@@ -23,9 +24,6 @@ from abeja.common.config import MOUNT_DIR, DEFAULT_CHUNK_SIZE
 # often sets random seed, it causes file name conflict. So we have our own
 # random generator.
 RANDOM = random.Random()
-
-# errno for "Stale file handle". Python's errno module doesn't define the value.
-E_STALE_FILE_HANDLE = 116
 
 
 def use_binary_cache(func):
@@ -155,7 +153,7 @@ def _read_file(path, file_type):
             return f.read()
         except OSError as exc:
             # The file is already deleted in the NFS server (EFS), try to re-open it and read.
-            if exc.errno == E_STALE_FILE_HANDLE:
+            if exc.errno == errno.ESTALE:
                 with open(path, mode) as f2:
                     return f2.read()
 

--- a/abeja/common/local_file.py
+++ b/abeja/common/local_file.py
@@ -11,6 +11,7 @@ local file is saved in MOUNT_DIR and follows the rules below.
 
 """
 import os
+import os.path
 from functools import wraps
 from urllib.parse import urlparse
 from datetime import datetime
@@ -22,6 +23,9 @@ from abeja.common.config import MOUNT_DIR, DEFAULT_CHUNK_SIZE
 # often sets random seed, it causes file name conflict. So we have our own
 # random generator.
 RANDOM = random.Random()
+
+# errno for "Stale file handle". Python's errno module doesn't define the value.
+E_STALE_FILE_HANDLE = 116
 
 
 def use_binary_cache(func):
@@ -147,7 +151,13 @@ def _read_file(path, file_type):
     if file_type == 'binary':
         mode += 'b'
     with open(path, mode) as f:
-        return f.read()
+        try:
+            return f.read()
+        except OSError as exc:
+            # The file is already deleted in the NFS server (EFS), try to re-open it and read.
+            if exc.errno == E_STALE_FILE_HANDLE:
+                with open(path, mode) as f2:
+                    return f2.read()
 
 
 def _read_iter_content_file(path, chunk_size):
@@ -182,7 +192,14 @@ def _write_iter_file(path, file_type, iter_content):
     mode = 'w'
     if file_type == 'binary':
         mode += 'b'
+
+    # Write cache contents to a temporary file, periodically check whether an other
+    # process has written the cache file or not. If so, this process will stop downloading
+    # contents as soon as possible and remove a temporary file.
     with open(tmppath, mode) as f:
         for content in iter_content:
             f.write(content)
+            if os.path.exists(path):
+                os.remove(tmppath)
+                return
     os.replace(tmppath, path)

--- a/abeja/common/local_file.py
+++ b/abeja/common/local_file.py
@@ -166,7 +166,7 @@ def _read_iter_content_file(path, chunk_size):
 
 def _read_iter_lines_file(path):
     with open(path, 'r') as f:
-        for line in f.readline():
+        for line in f:
             yield line
 
 

--- a/tests/common/test_local_file.py
+++ b/tests/common/test_local_file.py
@@ -1,6 +1,9 @@
 from abeja.common import local_file
-from abeja.common.local_file import use_text_cache, use_binary_cache
+from abeja.common.local_file import use_text_cache, use_binary_cache, use_iter_content_cache
+from abeja.common.config import DEFAULT_CHUNK_SIZE
 import pytest
+import secrets
+from functools import partial
 
 
 class SourceURI:
@@ -15,8 +18,8 @@ def mount_dir(monkeypatch, tmpdir):
 
 
 @pytest.fixture
-def read_cache_factory(mount_dir, tmp_path):
-    def factory(cache_func, content):
+def fake_file_factory(mount_dir, tmp_path):
+    def factory(content):
         filename = 'testfile'
         obj = SourceURI(f'http://example.com/files/{filename}')
         original = tmp_path / filename
@@ -28,21 +31,51 @@ def read_cache_factory(mount_dir, tmp_path):
             mode = 'rb'
             original.write_bytes(content)
 
-        with open(str(original), mode) as f:
-            decorated = cache_func(f.read)
-            return decorated(obj)
+        return open(str(original), mode), obj
     return factory
 
 
-def test_use_text_cache(read_cache_factory):
+@pytest.fixture
+def read_file_factory(fake_file_factory):
+    def factory(cache_func, content):
+        f, obj = fake_file_factory(content)
+
+        with f:
+            decorated = cache_func(f.read)
+            return decorated(obj), decorated(obj)
+    return factory
+
+
+@pytest.fixture
+def read_iter_factory(fake_file_factory):
+    def factory(cache_func, content):
+        f, obj = fake_file_factory(content)
+
+        def make_iter(chunk_size):
+            return iter(partial(f.read, chunk_size), b'')
+
+        with f:
+            decorated = cache_func(make_iter)
+            return decorated(obj), decorated(obj)
+    return factory
+
+
+def test_use_text_cache(read_file_factory):
     content = 'Hello, World!'
-    assert read_cache_factory(use_text_cache, content) == content
-    # Read from cache
-    assert read_cache_factory(use_text_cache, content) == content
+    saved, cached = read_file_factory(use_text_cache, content)
+    assert saved == content
+    assert cached == content
 
 
-def test_use_binary_cache(read_cache_factory):
+def test_use_binary_cache(read_file_factory):
     content = b'test'
-    assert read_cache_factory(use_binary_cache, content) == content
-    # Read from cache
-    assert read_cache_factory(use_binary_cache, content) == content
+    saved, cached = read_file_factory(use_binary_cache, content)
+    assert saved == content
+    assert cached == content
+
+
+def test_use_iter_content_cache(read_iter_factory):
+    content = secrets.token_bytes(int(DEFAULT_CHUNK_SIZE * 3.7))
+    saved, cached = read_iter_factory(use_iter_content_cache, content)
+    assert b''.join(list(saved)) == content
+    assert b''.join(list(cached)) == content

--- a/tests/common/test_local_file.py
+++ b/tests/common/test_local_file.py
@@ -37,8 +37,12 @@ def read_cache_factory(mount_dir, tmp_path):
 def test_use_text_cache(read_cache_factory):
     content = 'Hello, World!'
     assert read_cache_factory(use_text_cache, content) == content
+    # Read from cache
+    assert read_cache_factory(use_text_cache, content) == content
 
 
 def test_use_binary_cache(read_cache_factory):
     content = b'test'
+    assert read_cache_factory(use_binary_cache, content) == content
+    # Read from cache
     assert read_cache_factory(use_binary_cache, content) == content

--- a/tests/common/test_local_file.py
+++ b/tests/common/test_local_file.py
@@ -3,7 +3,6 @@ from abeja.common.local_file import use_text_cache, use_binary_cache, use_iter_c
 from abeja.common.config import DEFAULT_CHUNK_SIZE
 import pytest
 import secrets
-import io
 import errno
 from functools import partial
 import builtins

--- a/tests/common/test_local_file.py
+++ b/tests/common/test_local_file.py
@@ -110,11 +110,10 @@ def read_iter_factory(fake_file_factory, monkeypatch):
             sentinel = '' if isinstance(content, str) else b''
             return iter(partial(f.read, chunk_size), sentinel)
 
+        # We don't test raising "Stale file handle" error for iterator
         with f:
             decorated = cache_func(make_iter)
-            with monkeypatch.context() as m:
-                m.setattr(builtins, 'open', mock_open_factory())
-                return list(decorated(obj)), list(decorated(obj))
+            return decorated(obj), decorated(obj)
     return factory
 
 

--- a/tests/common/test_local_file.py
+++ b/tests/common/test_local_file.py
@@ -1,0 +1,21 @@
+from abeja.common import local_file
+from abeja.common.local_file import use_text_cache
+
+
+class SourceURI:
+    def __init__(self, uri: str) -> None:
+        self.uri = uri
+
+
+def test_use_binary_cache(monkeypatch, tmp_path, tmpdir):
+    content = 'Hello, World!'
+    filename = 'hello.txt'
+    monkeypatch.setattr(local_file, 'MOUNT_DIR', str(tmpdir))
+
+    obj = SourceURI(f'http://example.com/files/{filename}')
+    original = tmp_path / filename
+    original.write_text(content)
+
+    with open(str(original), 'r') as f:
+        decorated = use_text_cache(f.read)
+        assert decorated(obj) == content

--- a/tests/common/test_local_file.py
+++ b/tests/common/test_local_file.py
@@ -9,11 +9,15 @@ class SourceURI:
 
 
 @pytest.fixture
-def read_cache_factory(monkeypatch, tmp_path, tmpdir):
+def mount_dir(monkeypatch, tmpdir):
+    monkeypatch.setattr(local_file, 'MOUNT_DIR', str(tmpdir))
+    return tmpdir
+
+
+@pytest.fixture
+def read_cache_factory(mount_dir, tmp_path):
     def factory(cache_func, content):
         filename = 'testfile'
-        monkeypatch.setattr(local_file, 'MOUNT_DIR', str(tmpdir))
-
         obj = SourceURI(f'http://example.com/files/{filename}')
         original = tmp_path / filename
 

--- a/tests/datalake/test_file.py
+++ b/tests/datalake/test_file.py
@@ -472,6 +472,7 @@ class TestDatalakeFile(unittest.TestCase):
 
     @patch('abeja.common.local_file.MOUNT_DIR', TEST_MOUNT_DIR)
     def test_get_iter_lines(self):
+        self.text_data = 'a\nb\nc'
         datalake_file = DatalakeFile(None, uri=self.uri, type=type)
         mock_func = create_autospec(
             datalake_file._get_iter_lines_from_remote,


### PR DESCRIPTION
NFS サーバ側でファイルが削除されていた場合、`f.read()` で "Stale file handle" エラーが起こります。

現在の SDK 実装では、複数ジョブがキャッシュファイルを書き込むときにこのエラーが発生しえるため、以下のように対策しました。

1. キャッシュ対象のファイルを temporary なファイルに書き込んでいるときに、すでにキャッシュファイルが作られていないかをチェックし、作られている場合は書き込みを停止し temporary なファイルを削除
2. 1 だけでは競合状態を完全には避けられないので、"Stale file handle" エラー発生時にはファイルを open し直し