### PR TITLE
specify less than version 4 of protobuf as a dependency to prevent tensorboardX from breaking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ retrying = "~=1.3.3"
 tensorboardx = "==1.8"
 tomlkit = "^0.5.11"
 typing-extensions = "~=3.7"
+# Specify less than version 4 of protobuf as a dependency to prevent tensorboardX from breaking.
+# see https://github.com/lanpa/tensorboardX/issues/663
 protobuf = "<4"
 Sphinx = {version = "==1.6.7", optional = true }
 guzzle_sphinx_theme = {version = "==0.7.11", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ retrying = "~=1.3.3"
 tensorboardx = "==1.8"
 tomlkit = "^0.5.11"
 typing-extensions = "~=3.7"
+protobuf = "<4"
 Sphinx = {version = "==1.6.7", optional = true }
 guzzle_sphinx_theme = {version = "==0.7.11", optional = true }
 importlib-metadata = {version = "^2.0.0", optional = true}


### PR DESCRIPTION
https://github.com/abeja-inc/platform-planning/issues/3973

tensorboardX の依存ライブラリのバージョン指定が不完全だったため、protobuf の非互換な変更が取り込まれて sdk も動かなくなっていたのを、protobuf のバージョンを指定することで回避しました。