### PR TITLE
【OSS脆弱性対応】ABEJA Platform SDK が Python3.6 でもインストールできる＆dependabot alert もでないようにする

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool]
 [tool.poetry]
 name = "abeja-sdk"
-version = "2.1.3rc2"
+version = "2.1.4rc3"
 description = "ABEJA Platform Software Development Kit"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.6",
     "Intended Audience :: Developers",
     "Topic :: Internet :: WWW/HTTP",
     "Operating System :: OS Independent"


### PR DESCRIPTION
## SBI
https://www.notion.so/abejainc/ABEJA-Platform-SDK-Python3-6-dependabot-alert-349b0d51aba94098ab96f57bf1ce326d