### PR TITLE
【OSS脆弱性対応】ABEJA Platform SDK が Python3.6 でもインストールできる＆dependabot alert もでないようにする

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,11 @@ description = "ABEJA Platform Software Development Kit"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Intended Audience :: Developers",
     "Topic :: Internet :: WWW/HTTP",
     "Operating System :: OS Independent"


### PR DESCRIPTION
https://github.com/abeja-inc/abeja-platform-sdk/pull/71 の追加修正です