### PR TITLE
typing_extensions と urlib のバグ修正

### DIFF
--- a/abeja/common/connection.py
+++ b/abeja/common/connection.py
@@ -175,7 +175,7 @@ class Connection:
         """
         session = Session()
         retries = Retry(
-            total=self.max_retry_count, backoff_factor=1, method_whitelist=(
+            total=self.max_retry_count, backoff_factor=1, allowed_methods=(
                 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'), status_forcelist=(
                 500, 502, 503, 504), raise_on_status=False)
         session.mount('http://', HTTPAdapter(max_retries=retries))

--- a/abeja/common/source_data.py
+++ b/abeja/common/source_data.py
@@ -1,10 +1,8 @@
 from abc import abstractmethod
 from typing import Dict
 
-from typing_extensions import Protocol
 
-
-class SourceData(Protocol):
+class SourceData:
     @abstractmethod
     def get_content(self, cache: bool = True) -> bytes:
         raise NotImplementedError

--- a/abeja/services/api/client.py
+++ b/abeja/services/api/client.py
@@ -355,7 +355,7 @@ class APIClient(BaseAPIClient):
             .. code-block:: python
 
                response = api_client.stop_service(organization_id='1111111111111',
-                                                　deployment_id='9999999999999', service_id='ser-abc1111111111111')
+                                                　　　　　　　　deployment_id='9999999999999', service_id='ser-abc1111111111111')
 
         Params:
             - **organization_id** (str): organization_id
@@ -396,7 +396,7 @@ class APIClient(BaseAPIClient):
             .. code-block:: python
 
                response = api_client.stop_service(organization_id='1111111111111',
-                                                　deployment_id='9999999999999', service_id='ser-abc1111111111111')
+                                                　　　　　　　　deployment_id='9999999999999', service_id='ser-abc1111111111111')
 
         Params:
             - **organization_id** (str): organization_id


### PR DESCRIPTION
typing_extensions アンインストールに伴う import バグと urlib バージョン変更に伴う Retry メソッドの引数名変更のバグ修正です