### PR TITLE
新旧 urlib3 バージョン両方で Retry 関数が動くように修正

### DIFF
--- a/abeja/common/connection.py
+++ b/abeja/common/connection.py
@@ -174,10 +174,17 @@ class Connection:
         :return: session
         """
         session = Session()
-        retries = Retry(
-            total=self.max_retry_count, backoff_factor=1, allowed_methods=(
-                'GET', 'POST', 'PUT', 'PATCH', 'DELETE'), status_forcelist=(
-                500, 502, 503, 504), raise_on_status=False)
+        try:
+            retries = Retry(
+                total=self.max_retry_count, backoff_factor=1, allowed_methods=(
+                    'GET', 'POST', 'PUT', 'PATCH', 'DELETE'), status_forcelist=(
+                    500, 502, 503, 504), raise_on_status=False)
+        except TypeError:
+            retries = Retry(
+                total=self.max_retry_count, backoff_factor=1, method_whitelist=(
+                    'GET', 'POST', 'PUT', 'PATCH', 'DELETE'), status_forcelist=(
+                    500, 502, 503, 504), raise_on_status=False)
+
         session.mount('http://', HTTPAdapter(max_retries=retries))
         session.mount('https://', HTTPAdapter(max_retries=retries))
         return session


### PR DESCRIPTION
urlib3 の Retry 関数の引数が urlib3 バージョン更新後に `method_whitelist` -> `allowed_methods` に変更されました。
ABEJA Platform SDK では urlib3 バージョン更新後になっているので https://github.com/abeja-inc/abeja-platform-sdk/pull/84 の修正で allowed_methods を使用するように変更しましたが、SDK インストール環境によっては、古い urlib3 バージョンになっているケースもあるため、新旧 urlib3 バージョン両方で Retry 関数が動くように修正しました

## 確認したこと
- [x] urllib3 2.0.4 の環境（poetry install）で make test 実行すると正常動作すること
- [x] urllib3 1.25.2 にダウングレードした環境（poetry install -> poetry add urllib3==1.25.2）で make test 実行しても、正常動作すること

## SBI
https://www.notion.so/abejainc/Sentry-SQS-87f273b9d39b4f0cb007f3f45758b88c