### PR TITLE
Add lifetime "1year" of datalake channel files

### DIFF
--- a/abeja/datalake/api/client.py
+++ b/abeja/datalake/api/client.py
@@ -646,7 +646,8 @@ class APIClient(BaseAPIClient):
             - **file_obj** (a file-like object) : a file-like object to upload. It must implement the read method, and must return bytes.
             - **content_type** (str): content type of a file to be uploaded
             - **metadata** (dict): **[optional]** key-value pair of metadata for the file
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`, the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`.
+                                                 the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:
@@ -1347,7 +1348,8 @@ class APIClient(BaseAPIClient):
             - **file_location** (str): file location to store
             - **content_type** (str): content type of a file to be uploaded
             - **metadata** (dict): **[optional]** key-value pair of metadata for the file
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`.
+                                                 the file will be deleted after the specified time.
 
         Return type:
             dict
@@ -1427,7 +1429,8 @@ class APIClient(BaseAPIClient):
             - **organization_id** (str): ORGANIZATION_ID
             - **bucket_id** (str): BUCKET_ID
             - **target_dir** (str) : a directory to upload. Directory structure will be kept on a bucket.
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`.
+                                                 the file will be deleted after the specified time.
 
         Return type:
             dict

--- a/abeja/datalake/api/client.py
+++ b/abeja/datalake/api/client.py
@@ -646,7 +646,7 @@ class APIClient(BaseAPIClient):
             - **file_obj** (a file-like object) : a file-like object to upload. It must implement the read method, and must return bytes.
             - **content_type** (str): content type of a file to be uploaded
             - **metadata** (dict): **[optional]** key-value pair of metadata for the file
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`, the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:
@@ -1347,7 +1347,7 @@ class APIClient(BaseAPIClient):
             - **file_location** (str): file location to store
             - **content_type** (str): content type of a file to be uploaded
             - **metadata** (dict): **[optional]** key-value pair of metadata for the file
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
 
         Return type:
             dict
@@ -1427,7 +1427,7 @@ class APIClient(BaseAPIClient):
             - **organization_id** (str): ORGANIZATION_ID
             - **bucket_id** (str): BUCKET_ID
             - **target_dir** (str) : a directory to upload. Directory structure will be kept on a bucket.
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
 
         Return type:
             dict

--- a/abeja/datalake/channel.py
+++ b/abeja/datalake/channel.py
@@ -152,7 +152,7 @@ class Channel:
             - **file_obj** (a file-like object) : a file-like object to upload. It must implement the read method, and must return bytes.
             - **content_type** (str): MIME type of content.
             - **metadata** (dict): **[optional]** metadata to be added to uploaded file. Object can not be set to the key or value of dict. It must be a string.
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:
@@ -213,7 +213,7 @@ class Channel:
             - **file_path** (str) : path to a file
             - **metadata** (dict): **[optional]** metadata to be added to uploaed file.
             - **content_type** (str): **[optional]** MIME type of content. Content-Type is assumed by the extension if not specified.
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:
@@ -271,7 +271,7 @@ class Channel:
             - **content** (file-like object) : contents to be uploaded
             - **metadata** (dict): metadata to be added to uploaed file. **[optional]**
             - **content_type** (str): MIME type of content. Content-Type is assumed by extensions if not specified **[optional]**
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:

--- a/abeja/datalake/channel.py
+++ b/abeja/datalake/channel.py
@@ -152,7 +152,8 @@ class Channel:
             - **file_obj** (a file-like object) : a file-like object to upload. It must implement the read method, and must return bytes.
             - **content_type** (str): MIME type of content.
             - **metadata** (dict): **[optional]** metadata to be added to uploaded file. Object can not be set to the key or value of dict. It must be a string.
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`.
+                                                 the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:
@@ -213,7 +214,8 @@ class Channel:
             - **file_path** (str) : path to a file
             - **metadata** (dict): **[optional]** metadata to be added to uploaed file.
             - **content_type** (str): **[optional]** MIME type of content. Content-Type is assumed by the extension if not specified.
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`.
+                                                 the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:
@@ -271,7 +273,8 @@ class Channel:
             - **content** (file-like object) : contents to be uploaded
             - **metadata** (dict): metadata to be added to uploaed file. **[optional]**
             - **content_type** (str): MIME type of content. Content-Type is assumed by extensions if not specified **[optional]**
-            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`. the file will be deleted after the specified time.
+            - **lifetime** (str): **[optional]** each one of `1day` / `1week` / `1month` / `6months` / `1year`.
+                                                 the file will be deleted after the specified time.
             - **conflict_target** (str): **[optional]** return `409 Conflict` when the same value of specified key already exists in channel.
 
         Return type:

--- a/abeja/datalake/file.py
+++ b/abeja/datalake/file.py
@@ -61,7 +61,8 @@ class DatalakeFile(SourceData):
         '1day',
         '1week',
         '1month',
-        '6months'
+        '6months',
+        '1year',
     )
 
     def __init__(


### PR DESCRIPTION
https://github.com/abeja-inc/arms/pull/2114 の修正に伴い、データレイクチャンネル上ファイルの自動削除期間に１年（`"1year"`）を追加しました

## 確認したこと
dev 環境にて、以下を確認

- `post_channel_file_upload` の動作テスト
    - [x] "1year" でファイルアップロードしても正常レスポンスが得られること
      ```python
          ...
          content_type = "image/jpeg"
          metadata = {
              "x-abeja-meta-filename": "sample.jpg"
          }
          with open('sample.jpg', 'rb') as f:
              response = datalake_client.post_channel_file_upload(
                  channel_id=args.channel_id,
                  file_obj=f,
                  content_type=content_type,
                  metadata=metadata,
                  lifetime="1year"
              )
              print(f'response={response}')
      ```
      ```sh
      response={'uploaded_at': '2023-10-02T10:33:38Z', 'metadata': {'x-abeja-sys-meta-organizationid': '2818232766522', 'x-abeja-meta-filename': 'sample.jpg'}, 'lifetime': '1year', 'file_id': '20231002T103338-a8dc278e-4135-4d63-b98d-fc2102d337d5', 'content_type': 'image/jpeg'}
      ```
    - [x] Datalake DB 上の expired_at の値が１年後になっていること

- `put_channel_file_lifetime` の動作テスト
    - [x] `"1year"` で `lifetime` 設定しても正常レスポンスが得られること
      ```python
          response = datalake_client.put_channel_file_lifetime(
              channel_id=args.channel_id, 
              file_id="20231002T103338-a8dc278e-4135-4d63-b98d-fc2102d337d5",
              lifetime="1year"
          )
          print(f'response={response}')
      ```
      ```sh
      response={'lifetime': '1year', 'file_id': '20231002T103338-a8dc278e-4135-4d63-b98d-fc2102d337d5', 'channel_id': '3180977955732'}
      ```
    - [x] Datalake DB 上の expired_at の値が１年後になっていること
      <img width="1069" alt="image" src="https://github.com/abeja-inc/abeja-platform-sdk/assets/25688193/8039695d-25c1-4bd2-a02a-a0fa271e2dc4">
