### PR TITLE
[OpsBeeLLM] Add auth by JWT from ARMS

### DIFF
--- a/abeja/opsbeellm/common/connection.py
+++ b/abeja/opsbeellm/common/connection.py
@@ -1,8 +1,10 @@
+import base64
 import json
 import os
 import http
 from typing import Optional, Union, Text, IO, MutableMapping, Any
 from urllib.parse import urlparse
+from distutils.util import strtobool
 
 from requests import Session
 from requests.adapters import HTTPAdapter
@@ -10,6 +12,7 @@ from requests.exceptions import HTTPError as RequestsHTTPError
 from requests.packages.urllib3.util.retry import Retry
 
 from abeja import VERSION
+from abeja.common.auth import get_credential
 from abeja.exceptions import (
     HttpError,
     BadRequest,
@@ -30,8 +33,9 @@ DEFAULT_CONNECTION_TIMEOUT = 30
 
 class OpsBeeLLMConnection:
     """A connection to ABEJA Platform OpsBeeLLM API."""
-    BASE_URL = os.environ.get('ABEJA_OPSBEELLM_API_URL', 'https://opsbee-llm.stage.abeja.io')
-    API_TOKEN = os.environ.get('ABEJA_OPSBEELLM_API_TOKEN', 'dummy')
+    BASE_URL = os.environ.get('ABEJA_API_URL', 'https://api.stage.abeja.io')
+    OPSBEELLM_BASE_URL = os.environ.get('ABEJA_OPSBEELLM_API_URL', 'https://opsbee-llm.stage.abeja.io')
+    OPSBEELLM_API_TOKEN = os.environ.get('ABEJA_OPSBEELLM_API_TOKEN', 'dummy')
 
     def __init__(
             self,
@@ -43,12 +47,18 @@ class OpsBeeLLMConnection:
         self.max_retry_count = max_retry_count or os.environ.get(
             SDK_MAX_RETRY_COUNT_ENV_KEY) or DEFAULT_MAX_RETRY_COUNT
 
-        # TODO: MVP 版ではユーザーが設定した basic 認証の credential ではなく、JTW token での認証でアクセス
-        self.credential = {"auth_token": self.API_TOKEN}
-        # if credential is None:
-        #     self.credential = {"auth_token": self.API_TOKEN}
-        # else:
-        #     self.credential = credential
+        # ARMS 用 credential と OpsBeeLLM 用 credential を別々に管理
+        # TODO: OpsBeeLLM API を ARMS の Gateway 経由で呼び出すようにしたあとは、この処理は不要になる。
+        if credential is None:
+            self.credential = get_credential() or {}
+        else:
+            self.credential = credential
+        if 'user_id' in self.credential and not self.credential['user_id'].startswith(
+                "user-"):
+            self.credential['user_id'] = 'user-{}'.format(
+                self.credential['user_id'])
+
+        self.opsbee_credential = {"auth_token": self.OPSBEELLM_API_TOKEN}
 
     def api_request(
             self,
@@ -72,16 +82,39 @@ class OpsBeeLLMConnection:
         """
         if headers is None:
             headers = {}
+
+        # ARMS API にリクエストして、user_id と personal_access_token が正しいか確認。
+        # TODO: OpsBeeLLM API を ARMS の Gateway 経由で呼び出すようにしたあとは、この処理は不要になる。
+        USER_AUTH_ARMS = strtobool(os.environ.get('USER_AUTH_ARMS', 'True'))
+        if USER_AUTH_ARMS:
+            headers.update(self._set_user_agent())
+            headers.update(self._get_auth_header(self.credential))
+            try:
+                res = self.request(
+                    'GET',
+                    '{}{}'.format(self.BASE_URL, "/users/me"),
+                    data=data,
+                    json=json,
+                    headers=headers,
+                    **kwargs
+                )
+            except RequestsHTTPError as e:
+                http_error_handler(e)
+
+        # OpsBeeLLM API へのリクエスト
+        headers = {}
         headers.update(self._set_user_agent())
-        headers.update(self._get_auth_header())
+        headers.update(self._get_auth_header(self.opsbee_credential))
         try:
-            res = self.request(method,
-                               '{}{}'.format(self.BASE_URL, path),
-                               data=data,
-                               json=json,
-                               headers=headers,
-                               params=params,
-                               **kwargs)
+            res = self.request(
+                method,
+                '{}{}'.format(self.OPSBEELLM_BASE_URL, path),
+                data=data,
+                json=json,
+                headers=headers,
+                params=params,
+                **kwargs
+            )
             return res.json()
         except RequestsHTTPError as e:
             http_error_handler(e)
@@ -183,11 +216,20 @@ class OpsBeeLLMConnection:
         session.mount('https://', HTTPAdapter(max_retries=retries))
         return session
 
-    def _get_auth_header(self):
-        if self.credential.get('auth_token'):
+    def _get_auth_header(self, credential):
+        if credential.get('auth_token'):
             return {
                 'Authorization': 'Bearer {}'.format(
-                    self.credential['auth_token'])}
+                    credential['auth_token'])}
+        if credential.get('user_id') and credential.get(
+                'personal_access_token'):
+            user_id = credential['user_id']
+            personal_access_token = credential['personal_access_token']
+            base = '{}:{}'.format(user_id, personal_access_token)
+            encoded = base64.b64encode(base.encode('utf-8'))
+            return {
+                'Authorization': 'Basic {}'.format(encoded.decode('utf-8'))
+            }
         return {}
 
     def _set_user_agent(self):

--- a/abeja/opsbeellm/common/connection.py
+++ b/abeja/opsbeellm/common/connection.py
@@ -32,8 +32,8 @@ DEFAULT_CONNECTION_TIMEOUT = 30
 
 class OpsBeeLLMConnection:
     """A connection to ABEJA Platform OpsBeeLLM API."""
-    BASE_URL = os.environ.get('ABEJA_API_URL', 'https://api.stage.abeja.io')
-    OPSBEELLM_BASE_URL = os.environ.get('ABEJA_OPSBEELLM_API_URL', 'https://opsbee-llm.stage.abeja.io')
+    OPSBEELLM_BASE_URL = os.environ.get('ABEJA_OPSBEELLM_API_URL', 'https://opsbee-llm.abeja.io')
+    OPSBEELLM_AUTH_BASE_URL = os.environ.get('ABEJA_OPSBEELLM_AUTH_API_URL', 'https://api.abeja.io')
 
     def __init__(
             self,
@@ -82,7 +82,7 @@ class OpsBeeLLMConnection:
             try:
                 res = self.request(
                     'POST',
-                    f'{self.BASE_URL}/users/auth?email={self.credential["email"]}&password={self.credential["password"]}',
+                    f'{self.OPSBEELLM_AUTH_BASE_URL}/users/auth?email={self.credential["email"]}&password={self.credential["password"]}',
                     data=data,
                     json=json,
                     headers=headers,

--- a/tests/opsbeellm/dataset/api/test_client.py
+++ b/tests/opsbeellm/dataset/api/test_client.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import requests_mock
@@ -5,6 +6,7 @@ import requests_mock
 from abeja.opsbeellm.dataset import APIClient
 from abeja.exceptions import BadRequest
 
+os.environ['USER_AUTH_ARMS'] = 'False'
 ACCOUNT_ID = '1111111111111'
 ORGANIZATION_ID = '2222222222222'
 DATASET_ID = '3333333333333'

--- a/tests/opsbeellm/deployment/api/test_client.py
+++ b/tests/opsbeellm/deployment/api/test_client.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import requests_mock
@@ -5,6 +6,7 @@ import requests_mock
 from abeja.opsbeellm.deployment import APIClient
 from abeja.exceptions import BadRequest
 
+os.environ['USER_AUTH_ARMS'] = 'False'
 ACCOUNT_ID = '1111111111111'
 ORGANIZATION_ID = '2222222222222'
 DEPLOYMENT_ID = '3333333333333'
@@ -43,7 +45,6 @@ DEPLOYMENTS_RES = {
 
 
 class TestOpsBeeLLMAPIClient(unittest.TestCase):
-
     @requests_mock.Mocker()
     def test_get_deployments(self, m):
         # get-deployments-api mock

--- a/tests/opsbeellm/history/api/test_client.py
+++ b/tests/opsbeellm/history/api/test_client.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 import requests_mock
@@ -5,6 +6,7 @@ import requests_mock
 from abeja.opsbeellm.history import APIClient
 from abeja.exceptions import BadRequest
 
+os.environ['USER_AUTH_ARMS'] = 'False'
 ACCOUNT_ID = '1111111111111'
 ORGANIZATION_ID = '2222222222222'
 TAG_ID = '3333333333333'
@@ -129,7 +131,6 @@ METADATA_RES = {
 
 
 class TestOpsBeeLLMAPIClient(unittest.TestCase):
-
     @requests_mock.Mocker()
     def test_get_threads(self, m):
         # get-threads-api mock


### PR DESCRIPTION
OpsBeeLLM に ARMS から生成した JWT token での認証認可機能を追加しました。
他の SDK とは違い ユーザーIDとパーソナルアクセストークンでの Basic 認証ではなく、ユーザー email とログインパスワードをもとに ARMS から生成した JWT token での認証認可になります。

```python
from abeja.opsbeellm.history import APIClient as OpsBeeLLMHistoryAPIClient

credential = {"email": "abeja-platform-opsbee-llm@abejainc.com", "password": "dummy"}

# QA用入出力履歴作成
try:
    resp_history = OpsBeeLLMHistoryAPIClient(credential=credential).create_qa_history(
			account_id="3250913870852",                    # [Required] α版では "3250913870852"（ABEJA Platform OpsBeeLLM トライアル用アカウント）を設定してくだい
			organization_id="3250914890794",               # [Required] α版では "3250914890794"（ABEJA Platform OpsBeeLLM トライアル用オーガニゼーション）を設定してくだい
			deployment_id="3035902113344",                 # [Required] 作成したデプロイメントのIDを指定してください
			input_text="ABEJAについて教えて",                 # [Required] LLM への入力文を入力してください
			output_text="ABEJAは、スペイン語で「ミツバチ」の意味であり、植物の受粉を手伝い、世界の食料生産を支える存在として社名になっています。",  # [Required] LLM からの応答文を入力してください
			input_token_count=None,                        # [Optional] 必要に応じて、LLM への入力文のトークン数を指定してください。
			output_token_count=None,                       # [Optional] 必要に応じて、LLM からの出力文のトークン数を指定してください。
			tag_ids=[],                                    # [Optional] 必要に応じて、入出力履歴に付与するためのタグを List 型で設定してください。タグはあとからでも追加できます。
			metadata=[                                     # [Optional] 必要に応じて、入出力ペア履歴に関連付けさせたい key-value 形式のメタデータを List[dict] 型で設定してください。メタデータはあとからでも設定できます
			  {"関連部署": "ABEJA全体"},
      ],
		)
    print("resp_history: ", resp_history)
except Exception as e:
    print(f'Faild to create qa history | {e}')
```