### PR TITLE
[OpsBeeLLM] Fix OpsBeeLLM SDK for customer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.3.0
-- Add OpsBeeLLM (α version) SDK (#92)
+- Add OpsBeeLLM SDK (#92, #93, #94, #95, #96)
 
 # 2.2.4
 - Add lifetime "1year" of datalake channel files (#89)

--- a/abeja/opsbeellm/common/api_client.py
+++ b/abeja/opsbeellm/common/api_client.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from abeja.opsbeellm.common.connection import OpsBeeLLMConnection
+
+
+class OpsBeeLLMBaseAPIClient:
+    """A low-level client for ABEJA Platform OpsBeeLLM API"""
+
+    def __init__(
+            self,
+            credential: Optional[dict] = None,
+            timeout: Optional[int] = None,
+            max_retry_count: Optional[int] = None):
+        self._connection = OpsBeeLLMConnection(credential, timeout, max_retry_count)

--- a/abeja/opsbeellm/common/connection.py
+++ b/abeja/opsbeellm/common/connection.py
@@ -1,0 +1,293 @@
+import base64
+import json
+import os
+import http
+from typing import Optional, Union, Text, IO, MutableMapping, Any
+from urllib.parse import urlparse
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.exceptions import HTTPError as RequestsHTTPError
+from requests.packages.urllib3.util.retry import Retry
+
+from abeja import VERSION
+from abeja.common.auth import get_credential
+from abeja.exceptions import (
+    HttpError,
+    BadRequest,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    MethodNotAllowed,
+    Conflict,
+    InternalServerError
+)
+
+SDK_CONNECTION_TIMEOUT_ENV_KEY = 'ABEJA_SDK_CONNECTION_TIMEOUT'
+SDK_MAX_RETRY_COUNT_ENV_KEY = 'ABEJA_SDK_MAX_RETRY_COUNT'
+
+DEFAULT_MAX_RETRY_COUNT = 5
+DEFAULT_CONNECTION_TIMEOUT = 30
+
+
+class OpsBeeLLMConnection:
+    """A connection to ABEJA Platform OpsBeeLLM API."""
+    OPSBEELLM_API_URL = os.environ.get('OPSBEELLM_API_URL', 'https://api.abeja.io')
+
+    def __init__(
+            self,
+            credential=None,
+            timeout: Optional[int] = None,
+            max_retry_count: Optional[int] = None):
+        self.timeout = timeout or os.environ.get(
+            SDK_CONNECTION_TIMEOUT_ENV_KEY) or DEFAULT_CONNECTION_TIMEOUT
+        self.max_retry_count = max_retry_count or os.environ.get(
+            SDK_MAX_RETRY_COUNT_ENV_KEY) or DEFAULT_MAX_RETRY_COUNT
+
+        if credential is None:
+            self.credential = get_credential() or {}
+        else:
+            self.credential = credential
+        # ユーザーIDとパーソナルアクセストークンでの Basic 認証の場合
+        if 'user_id' in self.credential and not self.credential['user_id'].startswith(
+                "user-"):
+            self.credential['user_id'] = 'user-{}'.format(
+                self.credential['user_id'])
+
+    def api_request(
+            self,
+            method,
+            path,
+            data=None,
+            json=None,
+            headers=None,
+            params=None,
+            **kwargs):
+        """call platform opsbee-llm api and handle errors if needed
+
+        :param method:
+        :param path:
+        :param data:
+        :param headers:
+        :param params:
+        :param json:
+        :param kwargs:
+        :return: (dict) api response
+        """
+        if headers is None:
+            headers = {}
+
+        # ABEJA Platform OpsBeeLLM API へのリクエスト
+        if self.OPSBEELLM_API_URL in [
+            'https://api.dev.abeja.io',
+            'https://api.stage.abeja.io',
+            'https://api.abeja.io'
+        ]:
+            headers.update(self._set_user_agent())
+            headers.update(self._get_auth_header())
+            try:
+                res = self.request(method,
+                                   '{}{}'.format(self.OPSBEELLM_API_URL, path),
+                                   data=data,
+                                   json=json,
+                                   headers=headers,
+                                   params=params,
+                                   **kwargs)
+                return res.json()
+            except RequestsHTTPError as e:
+                http_error_handler(e)
+        # Customer OpsBeeLLM API へのリクエスト
+        else:
+            # auth API を呼び出し、JWT トークンを取得
+            try:
+                auth_headers = {}
+                auth_headers.update(self._set_user_agent())
+                auth_headers.update(self._get_auth_header())
+                auth_body = {
+                    'email': self.credential['email'],
+                    'password': self.credential['password']
+                }
+                res = self.request(
+                    'POST',
+                    f'{self.OPSBEELLM_API_URL}/auth',
+                    json=auth_body,
+                    headers=auth_headers,
+                    **kwargs
+                )
+                jwt_token = res.json()["token"]
+            except RequestsHTTPError as e:
+                http_error_handler(e)
+
+            # JWT トークンで OpsBeeLLM API へリクエスト
+            headers.update(self._set_user_agent())
+            headers.update({'Authorization': f'Bearer {jwt_token}'})
+            try:
+                res = self.request(
+                    method,
+                    '{}{}'.format(self.OPSBEELLM_API_URL, path),
+                    data=data,
+                    json=json,
+                    headers=headers,
+                    params=params,
+                    **kwargs
+                )
+                return res.json()
+            except RequestsHTTPError as e:
+                http_error_handler(e)
+
+    def service_request(
+            self,
+            subdomain: str,
+            path: str,
+            data: Union[None, Text, bytes, IO]=None,
+            json: Optional[Any]=None,
+            headers: Optional[MutableMapping[Text, Text]]=None,
+            params: Union[None, bytes, MutableMapping[Text, Text]]=None,
+            **kwargs):
+        """call service api and handle errors if needed
+
+        :param subdomain:
+        :param path:
+        :param data:
+        :param json:
+        :param headers:
+        :param params:
+        :param kwargs:
+        :return: (requests.Response)
+        """
+        if headers is None:
+            headers = {}
+        headers.update(self._set_user_agent())
+        headers.update(self._get_auth_header())
+
+        base = urlparse(self.BASE_URL)
+        target_url = '{}://{}.{}{}'.format(base.scheme,
+                                           subdomain, base.netloc, path)
+        try:
+            return self.request(
+                method='POST',
+                url=target_url,
+                data=data,
+                json=json,
+                headers=headers,
+                params=params,
+                **kwargs)
+        except RequestsHTTPError as e:
+            http_error_handler(e)
+
+    def request(
+            self,
+            method,
+            url,
+            data=None,
+            json=None,
+            headers=None,
+            params=None,
+            timeout=None,
+            **kwargs):
+        """make request with retry and timeout settings.
+
+        :param method:
+        :param url:
+        :param data:
+        :param json:
+        :param headers:
+        :param params:
+        :param timeout:
+        :param kwargs:
+        :return: (Response)
+        """
+        if timeout is None:
+            timeout = self.timeout
+        with self._generate_session() as session:
+            res = session.request(
+                method,
+                url,
+                data=data,
+                json=json,
+                params=params,
+                headers=headers,
+                timeout=timeout,
+                **kwargs)
+            res.raise_for_status()
+        return res
+
+    def _generate_session(self):
+        """generate simple session to retry
+        :return: session
+        """
+        session = Session()
+        try:
+            retries = Retry(
+                total=self.max_retry_count, backoff_factor=1, allowed_methods=(
+                    'GET', 'POST', 'PUT', 'PATCH', 'DELETE'), status_forcelist=(
+                    500, 502, 503, 504), raise_on_status=False)
+        except TypeError:
+            retries = Retry(
+                total=self.max_retry_count, backoff_factor=1, method_whitelist=(
+                    'GET', 'POST', 'PUT', 'PATCH', 'DELETE'), status_forcelist=(
+                    500, 502, 503, 504), raise_on_status=False)
+
+        session.mount('http://', HTTPAdapter(max_retries=retries))
+        session.mount('https://', HTTPAdapter(max_retries=retries))
+        return session
+
+    def _get_auth_header(self):
+        # JWT トークンの場合
+        if self.credential.get('auth_token'):
+            return {
+                'Authorization': 'Bearer {}'.format(
+                    self.credential['auth_token'])}
+
+        # ユーザーIDとパーソナルアクセストークンでの Basic 認証の場合
+        if self.credential.get('user_id') and self.credential.get(
+                'personal_access_token'):
+            user_id = self.credential['user_id']
+            personal_access_token = self.credential['personal_access_token']
+            base = '{}:{}'.format(user_id, personal_access_token)
+            encoded = base64.b64encode(base.encode('utf-8'))
+            return {
+                'Authorization': 'Basic {}'.format(encoded.decode('utf-8'))
+            }
+        return {}
+
+    def _set_user_agent(self):
+        return {'User-Agent': 'abeja-platform-sdk/{}'.format(VERSION)}
+
+
+STATUS_CODE_EXCEPTION_CLASS_MAP = {
+    400: BadRequest,
+    401: Unauthorized,
+    403: Forbidden,
+    404: NotFound,
+    405: MethodNotAllowed,
+    409: Conflict,
+    500: InternalServerError
+}
+
+
+def http_error_handler(e):
+    status_code = e.response.status_code
+    url = e.response.url
+    general_error_name = http.client.responses.get(status_code, 'unknown')
+    general_error_description = e.response.text
+    cls = STATUS_CODE_EXCEPTION_CLASS_MAP.get(
+        e.response.status_code, HttpError)
+    try:
+        res = e.response.json()
+    except json.JSONDecodeError:
+        raise cls(
+            general_error_name,
+            general_error_description,
+            status_code=status_code,
+            url=url)
+    # retrieve messages from response
+    error = res.get('error', general_error_name)
+    error_description = res.get('error_description', general_error_description)
+    error_detail = res.get('error_detail')
+    raise cls(
+        error,
+        error_description,
+        error_detail=error_detail,
+        status_code=status_code,
+        url=url)

--- a/abeja/opsbeellm/dataset/api/client.py
+++ b/abeja/opsbeellm/dataset/api/client.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from typing import Optional, List, Dict
-from abeja.common.api_client import BaseAPIClient
+from abeja.opsbeellm.common.api_client import OpsBeeLLMBaseAPIClient
 from abeja.exceptions import BadRequest
 
 
-class APIClient(BaseAPIClient):
+class APIClient(OpsBeeLLMBaseAPIClient):
     """A Low-Level client for OpsBee LLM Dataset API
 
     .. code-block:: python

--- a/abeja/opsbeellm/deployment/api/client.py
+++ b/abeja/opsbeellm/deployment/api/client.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from abeja.common.api_client import BaseAPIClient
+from abeja.opsbeellm.common.api_client import OpsBeeLLMBaseAPIClient
 from abeja.exceptions import BadRequest
 
 
-class APIClient(BaseAPIClient):
+class APIClient(OpsBeeLLMBaseAPIClient):
     """A Low-Level client for OpsBee LLM Deployment API
 
     .. code-block:: python

--- a/abeja/opsbeellm/history/api/client.py
+++ b/abeja/opsbeellm/history/api/client.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 from typing import Optional, List, Dict
 
-from abeja.common.api_client import BaseAPIClient
+from abeja.opsbeellm.common.api_client import OpsBeeLLMBaseAPIClient
 from abeja.exceptions import BadRequest
 
 
-class APIClient(BaseAPIClient):
+class APIClient(OpsBeeLLMBaseAPIClient):
     """A Low-Level client for OpsBee LLM History API
 
     .. code-block:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "abeja-sdk"
-version = "2.3.0.rc2"
+version = "2.3.0.rc3"
 description = "ABEJA Platform Software Development Kit"
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
顧客用 OpsBeeLLM のための OpsBeeLLM SDK 修正です。
顧客用 OpsBeeLLM SDK の使用方法は、以下のような手順になります

1. 顧客用 OpsBeeLLM のAPI エンドポイントを環境変数で設定
```sh
export OPSBEELLM_API_ENDPOINT="https://xxx.xxx.io"
```

2. email & password で credential 情報を設定
```python
credential = {"email": "abeja-platform-opsbee-llm@abejainc.com", "password": "dummy"}
```

3. OpsBeeLLM SDK を利用する
```python
try:
    resp_history = OpsBeeLLMHistoryAPIClient(credential=credential).create_qa_history(
			organization_id="3250914890794",               # 設定してくだい
			deployment_id="3035902113344",                 # [Required] 作成したデプロイメントのIDを指定してください
			input_text="ABEJAについて教えて",                 # [Required] LLM への入力文を入力してください
			output_text="ABEJAは、スペイン語で「ミツバチ」の意味であり、植物の受粉を手伝い、世界の食料生産を支える存在として社名になっています。",  # [Required] LLM からの応答文を入力してください
			input_token_count=None,                        # [Optional] 必要に応じて、LLM への入力文のトークン数を指定してください。
			output_token_count=None,                       # [Optional] 必要に応じて、LLM からの出力文のトークン数を指定してください。
			tag_ids=[],                                    # [Optional] 必要に応じて、入出力履歴に付与するためのタグを List 型で設定してください。タグはあとからでも追加できます。
			metadata=[                                     # [Optional] 必要に応じて、入出力ペア履歴に関連付けさせたい key-value 形式のメタデータを List[dict] 型で設定してください。メタデータはあとからでも設定できます
			  {"関連部署": "ABEJA全体"},
      ],
		)
    print("resp_history: ", resp_history)
except Exception as e:
    print(f'Faild to create qa history | {e}')
```