### PR TITLE
[OpsBeeLLM] Enable to input_text and output_text is empty in create history

### DIFF
--- a/abeja/opsbeellm/history/api/client.py
+++ b/abeja/opsbeellm/history/api/client.py
@@ -690,15 +690,8 @@ class APIClient(BaseAPIClient):
             - Unauthorized: Authentication failed
             - InternalServerError
         """
-        if not input_text:
-            error_message = '"input_text" is necessary'
-            raise BadRequest(
-                error=error_message,
-                error_description=error_message,
-                status_code=400
-            )
-        if not output_text:
-            error_message = '"output_text" is necessary'
+        if not input_text and not output_text:
+            error_message = '"input_text" or "output_text" is necessary'
             raise BadRequest(
                 error=error_message,
                 error_description=error_message,
@@ -1357,15 +1350,8 @@ class APIClient(BaseAPIClient):
             - Unauthorized: Authentication failed
             - InternalServerError
         """
-        if not input_text:
-            error_message = '"input_text" is necessary'
-            raise BadRequest(
-                error=error_message,
-                error_description=error_message,
-                status_code=400
-            )
-        if not output_text:
-            error_message = '"output_text" is necessary'
+        if not input_text and not output_text:
+            error_message = '"input_text" or "output_text" is necessary'
             raise BadRequest(
                 error=error_message,
                 error_description=error_message,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "abeja-sdk"
-version = "2.3.0"
+version = "2.3.1"
 description = "ABEJA Platform Software Development Kit"
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "abeja-sdk"
-version = "2.3.0rc3"
+version = "2.3.0"
 description = "ABEJA Platform Software Development Kit"
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/opsbeellm/history/api/test_client.py
+++ b/tests/opsbeellm/history/api/test_client.py
@@ -334,10 +334,10 @@ class TestOpsBeeLLMAPIClient(unittest.TestCase):
             'tag_ids': [],
             'metadata': [],
         }
-
         self.assertDictEqual(m.request_history[1].json(), expected_payload)
         self.assertDictEqual(ret, HISTORY_RES)
 
+        # 入出力テキスト両方なし
         with self.assertRaises(BadRequest) as e:
             client.create_qa_history(
                 ORGANIZATION_ID,
@@ -345,17 +345,9 @@ class TestOpsBeeLLMAPIClient(unittest.TestCase):
                 input_text=None,
                 output_text=None,
             )
-        self.assertEqual(e.exception.error_description, '"input_text" is necessary')
+        self.assertEqual(e.exception.error_description, '"input_text" or "output_text" is necessary')
 
-        with self.assertRaises(BadRequest) as e:
-            client.create_qa_history(
-                ORGANIZATION_ID,
-                DEPLOYMENT_QA_ID,
-                input_text=INPUT_TEXT,
-                output_text=None,
-            )
-        self.assertEqual(e.exception.error_description, '"output_text" is necessary')
-
+        # サポート外のでデプロイメントタイプ
         path = '/opsbee-llm/organizations/{}/deployments/{}'.format(
             ORGANIZATION_ID,
             DEPLOYMENT_CHAT_ID,
@@ -550,6 +542,7 @@ class TestOpsBeeLLMAPIClient(unittest.TestCase):
         self.assertDictEqual(m.request_history[1].json(), expected_payload)
         self.assertDictEqual(ret, HISTORY_RES)
 
+        # 入出力テキスト両方なし
         with self.assertRaises(BadRequest) as e:
             client.create_chat_history(
                 ORGANIZATION_ID,
@@ -558,18 +551,9 @@ class TestOpsBeeLLMAPIClient(unittest.TestCase):
                 input_text=None,
                 output_text=None,
             )
-        self.assertEqual(e.exception.error_description, '"input_text" is necessary')
+        self.assertEqual(e.exception.error_description, '"input_text" or "output_text" is necessary')
 
-        with self.assertRaises(BadRequest) as e:
-            client.create_chat_history(
-                ORGANIZATION_ID,
-                DEPLOYMENT_CHAT_ID,
-                THREAD_ID,
-                input_text=INPUT_TEXT,
-                output_text=None,
-            )
-        self.assertEqual(e.exception.error_description, '"output_text" is necessary')
-
+        # サポート外のでデプロイメントタイプ
         path = '/opsbee-llm/organizations/{}/deployments/{}'.format(
             ORGANIZATION_ID,
             DEPLOYMENT_QA_ID,


### PR DESCRIPTION
OpsBeeLLM の入出力履歴作成 SDK で、`input_text` と `output_text` 引数の空文字 or None を設定可能にしました