### PR TITLE
[OpsBeeLLM] Add search_query in get-histories

### DIFF
--- a/abeja/opsbeellm/history/api/client.py
+++ b/abeja/opsbeellm/history/api/client.py
@@ -381,6 +381,7 @@ class APIClient(BaseAPIClient):
             - **deployment_id** (str): deployment identifier for OpsBee LLM
             - **search_query** (str): **[optional]** search query
                 - available search keys is below:
+                    - `history_id:`
                     - `input_text:`
                     - `output_text:`
                     - `input_token_count:`
@@ -396,7 +397,7 @@ class APIClient(BaseAPIClient):
                 - `*` operators are available for `input_text:`, `output_text:` keys.
                 - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.
                 example:
-                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
+                    search_query='input_text:"ABEJA*" AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 
@@ -1063,6 +1064,7 @@ class APIClient(BaseAPIClient):
             - **deployment_id** (str): deployment identifier for OpsBee LLM
             - **search_query** (str): **[optional]** search query
                 - available search keys is below:
+                    - `history_id:`
                     - `input_text:`
                     - `output_text:`
                     - `input_token_count:`
@@ -1078,7 +1080,7 @@ class APIClient(BaseAPIClient):
                 - `*` operators are available for `input_text:`, `output_text:` keys.
                 - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.
                 example:
-                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
+                    search_query='input_text:"ABEJA*" AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 

--- a/abeja/opsbeellm/history/api/client.py
+++ b/abeja/opsbeellm/history/api/client.py
@@ -358,6 +358,7 @@ class APIClient(BaseAPIClient):
         self,
         organization_id: str,
         deployment_id: str,
+        search_query: Optional[str] = None,
         offset: Optional[int] = 0,
         limit: Optional[int] = 1000,
     ) -> dict:
@@ -378,6 +379,21 @@ class APIClient(BaseAPIClient):
         Params:
             - **organization_id** (str): organization identifier
             - **deployment_id** (str): deployment identifier for OpsBee LLM
+            - **search_query** (str): **[optional]** search query
+                available search keys is below and AND, OR operators are available for each keys.
+                - `input_text`: * operators are available.
+                - output_text: * operators are available.
+                - input_token_count: <=, <, >=, >, operators are available.
+                - output_token_count: <=, <, >=, >, operators are available.
+                - tag_ids:
+                - tag_names:
+                - metadata_ids:
+                - metadata_keys:
+                - metadata_values:
+                - created_at: <=, <, >=, >, operators are available.
+                - updated_at: <=, <, >=, >, operators are available.
+                example:
+                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 OR metadata_keys:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 
@@ -480,12 +496,22 @@ class APIClient(BaseAPIClient):
             )
 
         # get qa histories
-        path = '/opsbee-llm/organizations/{}/deployments/{}/qa_histories?offset={}&limit={}'.format(
-            organization_id,
-            deployment_id,
-            offset,
-            limit,
-        )
+        if search_query:
+            path = '/opsbee-llm/organizations/{}/deployments/{}/qa_histories?search_query={}&offset={}&limit={}'.format(
+                organization_id,
+                deployment_id,
+                search_query,
+                offset,
+                limit,
+            )
+        else:
+            path = '/opsbee-llm/organizations/{}/deployments/{}/qa_histories?offset={}&limit={}'.format(
+                organization_id,
+                deployment_id,
+                offset,
+                limit,
+            )
+
         return self._connection.api_request(method='GET', path=path, params=params)
 
     def get_qa_history(
@@ -1011,6 +1037,7 @@ class APIClient(BaseAPIClient):
         self,
         organization_id: str,
         deployment_id: str,
+        search_query: Optional[str] = None,
         offset: Optional[int] = 0,
         limit: Optional[int] = 1000,
     ) -> dict:
@@ -1031,6 +1058,21 @@ class APIClient(BaseAPIClient):
         Params:
             - **organization_id** (str): organization identifier
             - **deployment_id** (str): deployment identifier for OpsBee LLM
+            - **search_query** (str): **[optional]** search query
+                available search keys is below and AND, OR operators are available for each keys.
+                - `input_text`: * operators are available.
+                - output_text: * operators are available.
+                - input_token_count: <=, <, >=, >, operators are available.
+                - output_token_count: <=, <, >=, >, operators are available.
+                - tag_ids:
+                - tag_names:
+                - metadata_ids:
+                - metadata_keys:
+                - metadata_values:
+                - created_at: <=, <, >=, >, operators are available.
+                - updated_at: <=, <, >=, >, operators are available.
+                example:
+                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 OR metadata_keys:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 
@@ -1133,12 +1175,21 @@ class APIClient(BaseAPIClient):
             )
 
         # get chat histories
-        path = '/opsbee-llm/organizations/{}/deployments/{}/histories?offset={}&limit={}'.format(
-            organization_id,
-            deployment_id,
-            offset,
-            limit,
-        )
+        if search_query:
+            path = '/opsbee-llm/organizations/{}/deployments/{}/histories?search_query={}&offset={}&limit={}'.format(
+                organization_id,
+                deployment_id,
+                search_query,
+                offset,
+                limit,
+            )
+        else:
+            path = '/opsbee-llm/organizations/{}/deployments/{}/histories?offset={}&limit={}'.format(
+                organization_id,
+                deployment_id,
+                offset,
+                limit,
+            )
         return self._connection.api_request(method='GET', path=path, params=params)
 
     def get_chat_history(

--- a/abeja/opsbeellm/history/api/client.py
+++ b/abeja/opsbeellm/history/api/client.py
@@ -380,20 +380,12 @@ class APIClient(BaseAPIClient):
             - **organization_id** (str): organization identifier
             - **deployment_id** (str): deployment identifier for OpsBee LLM
             - **search_query** (str): **[optional]** search query
-                available search keys is below and AND, OR operators are available for each keys.
-                - `input_text`: * operators are available.
-                - output_text: * operators are available.
-                - input_token_count: <=, <, >=, >, operators are available.
-                - output_token_count: <=, <, >=, >, operators are available.
-                - tag_ids:
-                - tag_names:
-                - metadata_ids:
-                - metadata_keys:
-                - metadata_values:
-                - created_at: <=, <, >=, >, operators are available.
-                - updated_at: <=, <, >=, >, operators are available.
+                - available search keys is `input_text:`, `output_text:`, `input_token_count:`, `output_token_count:`, `tag_ids:`, `tag_names:`, `metadata_ids:`, `metadata_keys:`, `metadata_values;`, `created_at:`, `updated_at:`.
+                - AND and OR operators are available for each keys.
+                - `*` operators are available for `input_text:`, `output_text:` keys.
+                - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.
                 example:
-                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 OR metadata_keys:metadata2'
+                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 
@@ -1059,20 +1051,12 @@ class APIClient(BaseAPIClient):
             - **organization_id** (str): organization identifier
             - **deployment_id** (str): deployment identifier for OpsBee LLM
             - **search_query** (str): **[optional]** search query
-                available search keys is below and AND, OR operators are available for each keys.
-                - `input_text`: * operators are available.
-                - output_text: * operators are available.
-                - input_token_count: <=, <, >=, >, operators are available.
-                - output_token_count: <=, <, >=, >, operators are available.
-                - tag_ids:
-                - tag_names:
-                - metadata_ids:
-                - metadata_keys:
-                - metadata_values:
-                - created_at: <=, <, >=, >, operators are available.
-                - updated_at: <=, <, >=, >, operators are available.
+                - available search keys is `input_text:`, `output_text:`, `input_token_count:`, `output_token_count:`, `tag_ids:`, `tag_names:`, `metadata_ids:`, `metadata_keys:`, `metadata_values;`, `created_at:`, `updated_at:`.
+                - AND and OR operators are available for each keys.
+                - `*` operators are available for `input_text:`, `output_text:` keys.
+                - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.
                 example:
-                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 OR metadata_keys:metadata2'
+                    search_query='input_text:ABEJA* AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 

--- a/abeja/opsbeellm/history/api/client.py
+++ b/abeja/opsbeellm/history/api/client.py
@@ -386,18 +386,18 @@ class APIClient(BaseAPIClient):
                     - `output_text:`
                     - `input_token_count:`
                     - `output_token_count:`
-                    - `tag_ids:`
-                    - `tag_names:`
-                    - `metadata_ids:`
-                    - `metadata_keys:`
-                    - `metadata_values:`
+                    - `tag_id:`
+                    - `tag_name:`
+                    - `metadata_id:`
+                    - `metadata_key:`
+                    - `metadata_value:`
                     - `created_at:`
                     - `updated_at:`
                 - AND and OR operators are available for each keys.
                 - `*` operators are available for `input_text:`, `output_text:` keys.
                 - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.
                 example:
-                    search_query='input_text:"ABEJA*" AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
+                    search_query='input_text:"ABEJA*" AND input_token_count:>=10 AND metadata_key:metadata1 AND metadata_key:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 
@@ -1069,18 +1069,18 @@ class APIClient(BaseAPIClient):
                     - `output_text:`
                     - `input_token_count:`
                     - `output_token_count:`
-                    - `tag_ids:`
-                    - `tag_names:`
-                    - `metadata_ids:`
-                    - `metadata_keys:`
-                    - `metadata_values:`
+                    - `tag_id:`
+                    - `tag_name:`
+                    - `metadata_id:`
+                    - `metadata_key:`
+                    - `metadata_value:`
                     - `created_at:`
                     - `updated_at:`
                 - AND and OR operators are available for each keys.
                 - `*` operators are available for `input_text:`, `output_text:` keys.
                 - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.
                 example:
-                    search_query='input_text:"ABEJA*" AND input_token_count:>=10 AND metadata_keys:metadata1 AND metadata_keys:metadata2'
+                    search_query='input_text:"ABEJA*" AND input_token_count:>=10 AND metadata_key:metadata1 AND metadata_key:metadata2'
             - **offset** (int): **[optional]** offset of histories ( which starts from 0 )
             - **limit** (int): **[optional]** max number of histories to be returned
 

--- a/abeja/opsbeellm/history/api/client.py
+++ b/abeja/opsbeellm/history/api/client.py
@@ -380,7 +380,18 @@ class APIClient(BaseAPIClient):
             - **organization_id** (str): organization identifier
             - **deployment_id** (str): deployment identifier for OpsBee LLM
             - **search_query** (str): **[optional]** search query
-                - available search keys is `input_text:`, `output_text:`, `input_token_count:`, `output_token_count:`, `tag_ids:`, `tag_names:`, `metadata_ids:`, `metadata_keys:`, `metadata_values;`, `created_at:`, `updated_at:`.
+                - available search keys is below:
+                    - `input_text:`
+                    - `output_text:`
+                    - `input_token_count:`
+                    - `output_token_count:`
+                    - `tag_ids:`
+                    - `tag_names:`
+                    - `metadata_ids:`
+                    - `metadata_keys:`
+                    - `metadata_values:`
+                    - `created_at:`
+                    - `updated_at:`
                 - AND and OR operators are available for each keys.
                 - `*` operators are available for `input_text:`, `output_text:` keys.
                 - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.
@@ -1051,7 +1062,18 @@ class APIClient(BaseAPIClient):
             - **organization_id** (str): organization identifier
             - **deployment_id** (str): deployment identifier for OpsBee LLM
             - **search_query** (str): **[optional]** search query
-                - available search keys is `input_text:`, `output_text:`, `input_token_count:`, `output_token_count:`, `tag_ids:`, `tag_names:`, `metadata_ids:`, `metadata_keys:`, `metadata_values;`, `created_at:`, `updated_at:`.
+                - available search keys is below:
+                    - `input_text:`
+                    - `output_text:`
+                    - `input_token_count:`
+                    - `output_token_count:`
+                    - `tag_ids:`
+                    - `tag_names:`
+                    - `metadata_ids:`
+                    - `metadata_keys:`
+                    - `metadata_values:`
+                    - `created_at:`
+                    - `updated_at:`
                 - AND and OR operators are available for each keys.
                 - `*` operators are available for `input_text:`, `output_text:` keys.
                 - `<=`, `<`, `>=`, `>` operators are available for `input_token_count:`, `output_token_count:`, `created_at`, `updated_at` keys.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "abeja-sdk"
-version = "2.3.1"
+version = "2.3.2rc1"
 description = "ABEJA Platform Software Development Kit"
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tests/opsbeellm/history/api/test_client.py
+++ b/tests/opsbeellm/history/api/test_client.py
@@ -490,6 +490,22 @@ class TestOpsBeeLLMAPIClient(unittest.TestCase):
         )
         self.assertDictEqual(ret, HISTORIES_RES)
 
+        # search query
+        search_query = 'input_text:"ABEJA*"'
+        path = '/opsbee-llm/organizations/{}/deployments/{}/histories?search_query={}'.format(
+            ORGANIZATION_ID,
+            DEPLOYMENT_QA_ID,
+            search_query
+        )
+        m.get(path, json=HISTORIES_RES)
+
+        ret = client.get_chat_histories(
+            ORGANIZATION_ID,
+            DEPLOYMENT_QA_ID,
+            search_query=search_query,
+        )
+        self.assertDictEqual(ret, HISTORIES_RES)
+
     @requests_mock.Mocker()
     def test_get_chat_history(self, m):
         # get-deployment-api mock

--- a/tests/opsbeellm/history/api/test_client.py
+++ b/tests/opsbeellm/history/api/test_client.py
@@ -494,14 +494,14 @@ class TestOpsBeeLLMAPIClient(unittest.TestCase):
         search_query = 'input_text:"ABEJA*"'
         path = '/opsbee-llm/organizations/{}/deployments/{}/histories?search_query={}'.format(
             ORGANIZATION_ID,
-            DEPLOYMENT_QA_ID,
+            DEPLOYMENT_CHAT_ID,
             search_query
         )
         m.get(path, json=HISTORIES_RES)
 
         ret = client.get_chat_histories(
             ORGANIZATION_ID,
-            DEPLOYMENT_QA_ID,
+            DEPLOYMENT_CHAT_ID,
             search_query=search_query,
         )
         self.assertDictEqual(ret, HISTORIES_RES)

--- a/tests/opsbeellm/history/api/test_client.py
+++ b/tests/opsbeellm/history/api/test_client.py
@@ -274,6 +274,22 @@ class TestOpsBeeLLMAPIClient(unittest.TestCase):
         )
         self.assertDictEqual(ret, HISTORIES_RES)
 
+        # search query
+        search_query = 'input_text:"ABEJA*"'
+        path = '/opsbee-llm/organizations/{}/deployments/{}/qa_histories?search_query={}'.format(
+            ORGANIZATION_ID,
+            DEPLOYMENT_QA_ID,
+            search_query
+        )
+        m.get(path, json=HISTORIES_RES)
+
+        ret = client.get_qa_histories(
+            ORGANIZATION_ID,
+            DEPLOYMENT_QA_ID,
+            search_query=search_query,
+        )
+        self.assertDictEqual(ret, HISTORIES_RES)
+
     @requests_mock.Mocker()
     def test_get_qa_history(self, m):
         # get-deployment-api mock


### PR DESCRIPTION
OpsBeeLLM SDK の入出力一覧取得メソッドにて、`search_query` 引数を追加し検索クエリでの検索を行えるようにしました