### PR TITLE
Change release strategy from git-flow to PR-based workflow

### DIFF
--- a/.circleci/bump_version_rc.sh
+++ b/.circleci/bump_version_rc.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-VERSION=`PYTHONPATH=./ poetry version | cut -d ' ' -f 2`
-
-if [ `echo "${VERSION}" | grep "rc"` ]; then
-    poetry version "${VERSION}"
-else
-    poetry version "${VERSION}rc1"
-fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,10 @@ release-rc: &release-rc
       keys:
       - v1-dependencies-{{ checksum "poetry.lock" }}
   - *install-release-dependencies
-  - run: sh .circleci/bump_version_rc.sh
+  - run:
+      name: Bump RC version
+      command: |
+        poetry version $(PYTHONPATH=./ poetry run python tools/get_next_rc_version.py)
   - *replace-version
   - *run-release
   - *trigger-system-test
@@ -118,6 +121,6 @@ workflows:
           filters:
             branches:
               only:
-                - /^release\/.*/
+                - staging
           requires:
             - codetest

--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -1,0 +1,55 @@
+name: Auto Tag on Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "refs/tags/${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.get_version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.get_version.outputs.version }} does not exist"
+          fi
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.get_version.outputs.version }}
+          git push origin ${{ steps.get_version.outputs.version }}
+          echo "✅ Created and pushed tag: ${{ steps.get_version.outputs.version }}"
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          body: |
+            Release ${{ steps.get_version.outputs.version }}
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md) for details.
+          draft: false
+          prerelease: false
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.3.6
+- Change release strategy from git-flow to PR-based workflow
+
 # 2.3.5
 - [APF SecretManager] Add integration service in labs sdk #106
 - 【APF SecretManager】APF SDK からセキュアに利用できるようにする #105

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ $ pip install abeja-sdk>=1.0.0 --pre
 If you have bigger version than latest pre-release, bigger not-pre-release version in installed.
 For example, when there are versions of `1.0.1` and `1.0.0rc1`, `1.0.1` is installed even if you specify `--pre` option.
 
-Release candidate is published when release branch is pushed to Github.
+Release candidate is published when staging branch is pushed to Github.
 
 もし、最新のプレリリース版よりも新しいバージョンがある場合はそのバージョンがインストールされます。
 例えば、 `1.0.1` と `1.0.0rc1` というバージョンがある場合、 `--pre` オプションを指定しても、 `1.0.1` がインストールされます。
 
-release ブランチがGithubにプッシュされると、リリース候補版が公開されます。
+staging ブランチがGithubにプッシュされると、リリース候補版が公開されます。
 
 ### Using requirements.txt
 
@@ -95,49 +95,27 @@ $ poetry install
 
 ## Release
 
-Synchronize master and develop branch.
+### Deploy to Development Environment
 
-まず、master ブランチとdevelop ブランチをpull します。
+When creating a PR from `feature/xxx` to `develop` branch, include version updates in the PR:
+- Update `CHANGELOG.md`: Add your changes to the latest version section (do not create a new version section if the current version hasn't been released to staging yet)
+- Update `pyproject.toml` version (e.g., `2.3.5` → `2.3.6`)
 
-```bash
-$ git checkout master
-$ git pull
-$ git checkout develop
-$ git pull
-```
+> **Note**: If the current version in `pyproject.toml` has never been released to staging, you don't need to create a new version section in `CHANGELOG.md` or update `pyproject.toml`. Instead, add your changes to the existing latest version section in `CHANGELOG.md`. Only create a new version section and update `pyproject.toml` when the previous version has been released to staging. Alternatively, update the version only when creating a PR to `staging` to avoid version gaps in PyPI releases.
 
-Create release branch and prepare for release.
+Then create a PR and merge from `feature/xxx` to `develop` branch.
 
-続いて、リリース用ブランチを作成し、リリースの準備をします。
-※ rc2 以上を作る場合はpyproject.toml のversion を明示的に指定する必要があります。
+### Deploy to Staging Environment
 
-```bash
-$ git flow release start X.X.X
-$ vim CHANGELOG.md
-# update to new version
-$ poetry version X.X.X
-$ git add pyproject.toml
-$ git add CHANGELOG.md
-$ git commit -m "bump version"
-$ git flow release publish X.X.X
-```
+Create a PR and merge from `develop` to `staging` branch.
 
-After pushing to relase branch, RC package is published to packagecloud.
+After pushing to staging branch, RC package is automatically published to PyPI with the next available RC version (e.g., `2.3.6rc1`, `2.3.6rc2`, ...). The RC version number is automatically determined by querying PyPI for existing RC versions.
 
-Check CircleCI result.
-If the build succeeded then execute:
+### Deploy to Production Environment
 
-リリース用ブランチにpush した後、RC パッケージはpackagecloud に公開されます。
+Create a PR and merge from `staging` to `master` branch.
 
-CircleCI の結果を確認します。
-ビルドに成功したら、次を実行します:
-
-```bash
-$ git flow release finish X.X.X
-$ git push origin develop
-$ git push origin master
-$ git push origin X.X.X
-```
+After pushing to master branch, the final package (e.g., `2.3.6`) is published to PyPI.
 
 ## 実装中のSDK をローカルで利用する方法
 以下のコマンドでwheel ファイルを作成する。dist ディレクトリに`abeja_sdk-x.x.x-py3-none-any.whl` というファイルが爆誕。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "abeja-sdk"
-version = "2.3.5"
+version = "2.3.6"
 description = "ABEJA Platform Software Development Kit"
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/tools/get_next_rc_version.py
+++ b/tools/get_next_rc_version.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""
+Get the next RC version number for the current version in pyproject.toml.
+
+This script:
+1. Reads the current version from pyproject.toml
+2. Queries PyPI API to find existing RC versions for that version
+3. Returns the next RC version (e.g., if 2.3.6rc1 and 2.3.6rc2 exist, returns 2.3.6rc3)
+"""
+
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def get_version_from_pyproject():
+    """Extract version from pyproject.toml"""
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "r") as f:
+        for line in f:
+            if line.strip().startswith("version ="):
+                # Extract version from: version = "2.3.6"
+                match = re.search(r'version\s*=\s*"([^"]+)"', line)
+                if match:
+                    return match.group(1)
+    raise ValueError("Could not find version in pyproject.toml")
+
+
+def get_pypi_versions(package_name="abeja-sdk"):
+    """Get all versions from PyPI"""
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as response:
+            data = json.loads(response.read())
+            return list(data.get("releases", {}).keys())
+    except Exception as e:
+        print(f"Warning: Could not fetch versions from PyPI: {e}", file=sys.stderr)
+        return []
+
+
+def get_next_rc_version(base_version, existing_versions):
+    """Find the next RC version number"""
+    # Filter versions that match the base version with rc suffix
+    rc_pattern = re.compile(rf"^{re.escape(base_version)}rc(\d+)$")
+    rc_numbers = []
+
+    for version in existing_versions:
+        match = rc_pattern.match(version)
+        if match:
+            rc_numbers.append(int(match.group(1)))
+
+    if rc_numbers:
+        next_rc = max(rc_numbers) + 1
+    else:
+        next_rc = 1
+
+    return f"{base_version}rc{next_rc}"
+
+
+def main():
+    try:
+        base_version = get_version_from_pyproject()
+        existing_versions = get_pypi_versions()
+        next_rc_version = get_next_rc_version(base_version, existing_versions)
+        print(next_rc_version, end="")
+        return 0
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## 概要
git-flowベースのリリース戦略をPRベースのワークフローに変更しました。

## 変更内容

### 1. README.md
- git-flowのリリース手順を削除
- PRベースのワークフローに変更
  - Dev環境: `feature/xxx` → `develop` (PR)
  - Staging環境: `develop` → `staging` (PR)
  - Production環境: `staging` → `master` (PR)
- バージョン更新のタイミングと注意事項を追加
- RCリリースの説明を更新（`release`ブランチ → `staging`ブランチ）

### 2. .circleci/config.yml
- staging環境のRCパッケージリリーストリガーを`/^release\/.*/`から`staging`ブランチに変更
- `bump_version_rc.sh`の呼び出しを`tools/get_next_rc_version.py`に変更

### 3. CHANGELOG.md
- バージョン2.3.6のエントリを追加
- 「Change release strategy from git-flow to PR-based workflow」を記録

### 4. pyproject.toml
- バージョンを2.3.5から2.3.6に更新

### 5. tools/get_next_rc_version.py (新規作成)
- `bump_version_rc.sh`を廃止し、PyPI APIから既存のRCバージョンを確認して次のRC番号を自動決定するスクリプトを作成
- stagingブランチへのマージ時に自動で`rc1`, `rc2`, `rc3`...の順番でバージョンが生成される

### 6. .github/workflows/auto-tag-on-release.yml (新規作成)
- `master`ブランチへのマージ時に自動でGitタグとGitHub Releaseを作成
- `pyproject.toml`からバージョンを取得
- `actions/checkout@v4`を使用

## 参考
- model_api PR #1179と同様の変更
- datalake PR #613と同様の変更
- platform-dataset-api PR #101と同様の変更
- platform-agent PR #195と同様の変更
- abeja-platform-cli PR #67と同様の変更