### PR TITLE
Finish GitHub Actions release cutover

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -3,10 +3,11 @@
 This repository uses separate workflows for unit tests, live integration tests,
 and package releases.
 
-The first migration pull request deliberately keeps `.circleci/config.yml` and
-`tools/trigger_build_system_test.py` so the old and new test paths can be
-observed on the same commit. Do not promote that parallel configuration to
-`staging`: the two providers would both try to publish a release.
+The first migration pull request deliberately kept `.circleci/config.yml` and
+`tools/trigger_build_system_test.py` so the old and new test paths could be
+observed on the same commit. The cutover commit removes both legacy paths and
+the local credential-based publishing target before promotion to `staging`;
+never restore both publishers on a release branch.
 
 ## Workflows
 
@@ -215,9 +216,10 @@ or tagging an unverified artifact.
    required yet.
 5. Merge the parallel migration to `develop`, verify both push paths, and
    observe the agreed stability period.
-6. When all release Environments, Trusted Publishers, App permissions, target
-   receiver, and recovery steps are verified, remove the CircleCI config and
-   helper in a cutover commit on `develop`. Do not promote a commit containing
+6. In the cutover commit on `develop`, remove the CircleCI config, the
+   system-test trigger helper, and the `TWINE_USERNAME`/`TWINE_PASSWORD`
+   publishing target. Confirm those legacy paths remain absent before opening
+   the `develop` to `staging` pull request. Do not promote a commit containing
    both publishers to `staging`.
 7. Immediately before the first `staging` promotion, use CircleCI's reversible
    block on new work if the project can still start pipelines, then drain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ poetry install
 poetry run pre-commit install
 
 # Create local wheel for testing
-make release
+make dist
 ```
 
 ## Environment Variables

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,3 @@ format:
 .PHONY: docs
 docs:
 	PYTHONWARNINGS=ignore poetry run sphinx-build -M html doc/source doc/build -v
-
-.PHONY: release
-release: dist
-	poetry publish -u ${TWINE_USERNAME} -p ${TWINE_PASSWORD}

--- a/tests/tools/test_github_actions_workflows.py
+++ b/tests/tools/test_github_actions_workflows.py
@@ -19,6 +19,16 @@ def test_release_and_live_integration_runs_are_queued():
     assert "cancel-in-progress: false" not in integration
 
 
+def test_circleci_and_long_lived_pypi_credentials_stay_removed():
+    makefile = (ROOT / "Makefile").read_text()
+
+    assert not (ROOT / ".circleci" / "config.yml").exists()
+    assert not (ROOT / "tools" / "trigger_build_system_test.py").exists()
+    assert "TWINE_USERNAME" not in makefile
+    assert "TWINE_PASSWORD" not in makefile
+    assert "poetry publish" not in makefile
+
+
 def test_migrated_external_actions_are_commit_pinned():
     migrated_workflows = (
         "integration-test.yml",


### PR DESCRIPTION
## Summary

- remove the local `make release` target that still accepted `TWINE_USERNAME` / `TWINE_PASSWORD`
- document that releases now use GitHub Actions and PyPI Trusted Publishing
- add a regression test that keeps CircleCI and long-lived PyPI credential paths removed

This is the four-file follow-up that was pushed just after #120 merged. It is
rebased onto the current `develop` revision so it is included before the
`develop → staging` review PR.

## Validation

- `uv run --no-project --python 3.8 --with pytest==5.4.2 -- python -m pytest -q --confcutdir=tests/tools tests/tools` — 38 passed
- `git diff --check origin/develop...HEAD` — passed
- migration validator policy scan — 0 errors / 0 warnings; zizmor passed
- local actionlint 1.7.12 still rejects GitHub's current `queue: max` and `vulnerability-alerts` syntax; pinact comment verification was rate-limited by the unauthenticated GitHub API

Refs #112
