### PR TITLE
Bind SDK releases to published wheel provenance

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -112,6 +112,10 @@ check through the public Checks REST API and compares its wheel digest with
 PyPI before accepting the dispatch. The target authenticates that public read
 with its read-only CI GitHub App to avoid the low shared anonymous API rate
 limit; no SDK repository secret crosses the repository boundary.
+Before staging, install that separate read App on `abeja-platform-sdk` with
+Actions and Checks read access and verify the target can mint its downscoped
+token. This is distinct from the SDK-owned App that dispatches
+`platform-system-test`.
 
 The release-provenance contract is exact:
 
@@ -230,10 +234,12 @@ with PyPI. It skips the upload only when they match exactly and fails closed on
 any mismatch or yanked wheel. The build artifact is retained for 31 days,
 covering GitHub's 30-day workflow rerun window.
 
-The target rejects human dispatches and accepts only the configured SDK GitHub
-App bot. Recovery must therefore rerun the failed SDK workflow jobs so that the
-existing App-authenticated dispatch and provenance checks are reused. Do not
-manually dispatch the target or manually create the production tag or GitHub
+The target rejects new human dispatches and accepts only the configured SDK
+GitHub App bot. If the target dispatch was never accepted, rerun the failed SDK
+workflow jobs so that the App-authenticated dispatch and provenance checks are
+reused. If the linked target run exists but fails, rerun its failed jobs;
+rerunning the SDK dispatch only reconciles and exits after finding that run.
+Do not manually create a new target dispatch, production tag, or GitHub
 Release. If the rerun window has closed, or if the PyPI version is missing,
 yanked, or has a different digest, stop and escalate to the release owners for
 a separately reviewed recovery; use a new package version rather than

--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -27,14 +27,15 @@ never restore both publishers on a release branch.
   before the Environment is accessed.
 - `Release` calls both test workflows, builds one wheel, verifies that the
   target system-test workflow is dispatchable, publishes the wheel, and then
-  triggers `platform-system-test`. Integration credentials are
-  mandatory in this release path. A successful release means that the target
-  registered the uniquely identified dispatch; it does not wait for the target
-  run to finish. A retry first reconciles target runs by source run ID, SDK
-  version, and release stage, and fails if it finds duplicates. On `master`, a
-  final checkout-free job then reconciles the immutable tag and GitHub Release
-  through the API. An identical existing tag/release is a safe no-op; a
-  conflicting target or release metadata fails closed.
+  records the verified PyPI file as a public GitHub check run, and then triggers
+  `platform-system-test`. Integration credentials are mandatory in this release
+  path. A successful release means that the target registered the uniquely
+  identified dispatch; it does not wait for the target run to finish. A retry
+  first reconciles both the provenance check and target runs, and fails on
+  duplicate or conflicting state. On `master`, a final checkout-free job then
+  reconciles the immutable tag and GitHub Release through the API. An identical
+  existing tag/release is a safe no-op; a conflicting target or release
+  metadata fails closed.
 
 Python 3.8 and Poetry 1.8.0 are intentionally fixed for the initial migration.
 The current pytest and mypy versions do not support a Python 3.10/3.11 test
@@ -45,7 +46,7 @@ matrix. Upgrade the development dependencies before expanding the matrix.
 | Event | Eligible refs / callers | Trust and credentials | Jobs and side effects |
 | --- | --- | --- | --- |
 | `pull_request` | Targets `develop`, `staging`, or `master` | Unit tests are unprivileged. Integration receives local Environment secrets only for a same-repository, non-Dependabot head. | Stable `Unit tests` gate; optional serialized integration test; no writes. |
-| `push` | `develop` for tests; `staging` and `master` for release | Protected repository code. Integration uses its Environment; publishing and dispatch credentials remain in separate jobs. | Tests on `develop`; serialized build/publish/dispatch on release branches; production tag/release reconciliation on `master`. |
+| `push` | `develop` for tests; `staging` and `master` for release | Protected repository code. Integration uses its Environment; OIDC publishing, Checks write, and dispatch credentials remain in separate checkout-free jobs. | Tests on `develop`; serialized build/publish/provenance-check/dispatch on release branches; production tag/release reconciliation on `master`. |
 | `workflow_dispatch` | Unit: any ref, no secrets. Integration: only the three named branches. | Integration is skipped before Environment access for every other ref. | Manual validation only; no package publication. |
 | `workflow_call` | Unit: public reusable workflow. Integration: same repository only, with the original event/ref restrictions still enforced. | The release caller forwards no secrets. The integration job resolves this repository's protected Environment secrets only after its repository guard passes. | Test jobs only. The static unit concurrency prefix cannot cancel its caller. |
 
@@ -100,6 +101,45 @@ checksum-verified fixed `uv` version only when the package version is absent.
 exchange succeeds. PEP 740 attestations are intentionally disabled for this
 initial migration; add a separately reviewed attestation step before enabling
 them.
+
+After either verifying an identical existing wheel or publishing and verifying
+a new wheel, a dedicated checkout-free job downloads the build artifact and
+re-verifies its embedded package name/version, exact filename, SHA-256, and
+non-yanked state against public PyPI. That job has only `checks: write`; the
+OIDC-enabled publish job does not receive Checks permission. It then creates a
+completed GitHub check run before dispatch. `platform-system-test` reads this
+check through the public Checks REST API and compares its wheel digest with
+PyPI before accepting the dispatch. The target authenticates that public read
+with its read-only CI GitHub App to avoid the low shared anonymous API rate
+limit; no SDK repository secret crosses the repository boundary.
+
+The release-provenance contract is exact:
+
+- `name`: `ABEJA SDK release provenance`
+- `app.slug`: `github-actions`
+- `head_sha`: the 40-character release source SHA
+- `external_id`:
+  `abeja-sdk-release-provenance:v1:<run-id>:<run-attempt>:<package-version>:<wheel-sha256>`
+- `details_url`:
+  `https://github.com/abeja-inc/abeja-platform-sdk/actions/runs/<run-id>/attempts/<run-attempt>`
+- `status` / `conclusion`: `completed` / `success`
+- `output.title`: `ABEJA SDK release provenance v1`
+- `output.summary`: one compact JSON object with lexicographically sorted keys.
+  Every value, including the positive run identifiers, is a JSON string:
+
+```json
+{"package":"abeja-sdk","package_version":"<package-version>","release_stage":"<staging-or-production>","schema":"abeja-sdk-release-provenance/v1","source_head_sha":"<40-lowercase-hex>","source_repository":"abeja-inc/abeja-platform-sdk","source_run_attempt":"<run-attempt>","source_run_id":"<run-id>","source_workflow":".github/workflows/release.yml","wheel_filename":"<wheel-filename>","wheel_sha256":"<64-lowercase-hex>"}
+```
+
+Consumers list all checks with that name for the source SHA using
+`GET /repos/abeja-inc/abeja-platform-sdk/commits/<sha>/check-runs`, select the
+exact `external_id`, and reject missing, duplicate, or conflicting records.
+They must also compare `wheel_filename` and `wheel_sha256` with the PyPI JSON
+response and verify the `Publish to PyPI` job in the recorded workflow-run
+attempt. `source_run_attempt` is the successful publish job's attempt, preserved
+as a job output: rerunning only a failed provenance or dispatch job therefore
+reuses the same identical check. Rerunning the publish job records its new
+attempt and produces a distinct external ID.
 
 Restrict `pypi-staging` to `staging` and `pypi-production` to `master`. Add a
 required reviewer to `pypi-production` if the repository's release policy
@@ -187,17 +227,17 @@ jobs**, not **Re-run all jobs**. A full staging rerun recalculates the next RC
 from PyPI and can intentionally produce a new version. On a failed publish-job
 retry, the workflow compares the downloaded artifact's filename and SHA-256
 with PyPI. It skips the upload only when they match exactly and fails closed on
-any mismatch or yanked wheel. The build artifact is retained for seven days;
-after that window, compare the PyPI digest with the version, filename, source
-SHA, and wheel SHA-256 recorded in the build job summary.
+any mismatch or yanked wheel. The build artifact is retained for 31 days,
+covering GitHub's 30-day workflow rerun window.
 
-For an exact staging match, manually dispatch the target with the recorded RC
-version and source identifiers; do not create a tag or GitHub Release. For an
-exact production match, manually dispatch the target, then create the missing
-tag at the recorded source SHA and the matching GitHub Release. Never move an
-existing tag. If the PyPI version is missing, yanked, or has a different digest,
-stop recovery and investigate; use a new package version rather than dispatching
-or tagging an unverified artifact.
+The target rejects human dispatches and accepts only the configured SDK GitHub
+App bot. Recovery must therefore rerun the failed SDK workflow jobs so that the
+existing App-authenticated dispatch and provenance checks are reused. Do not
+manually dispatch the target or manually create the production tag or GitHub
+Release. If the rerun window has closed, or if the PyPI version is missing,
+yanked, or has a different digest, stop and escalate to the release owners for
+a separately reviewed recovery; use a new package version rather than
+dispatching or tagging unverified evidence.
 
 ## Migration and decommission checklist
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,9 @@ jobs:
           path: dist/*.whl
           if-no-files-found: error
           overwrite: true
-          retention-days: 7
+          # GitHub permits workflow reruns for 30 days. Keep the immutable
+          # wheel available through that entire recovery window.
+          retention-days: 31
 
   system-test-readiness:
     name: Verify platform system-test workflow
@@ -251,6 +253,8 @@ jobs:
       - system-test-readiness
     runs-on: ubuntu-22.04
     timeout-minutes: 15
+    outputs:
+      run-attempt: ${{ steps.publish-attempt.outputs.run-attempt }}
     # Trusted Publishing exposes OIDC only to this minimal, checkout-free job.
     permissions:
       contents: read # Recheck the protected release ref before first publish.
@@ -438,11 +442,334 @@ jobs:
                   )
               time.sleep(6)
 
+      # A failed downstream job may be rerun in a later workflow attempt
+      # without rerunning this successful publish job. Preserve the attempt
+      # whose job result platform-system-test must verify.
+      - name: Record successful publish attempt
+        id: publish-attempt
+        run: printf 'run-attempt=%s\n' "$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+
+  record-release-provenance:
+    name: Record verified release provenance
+    needs:
+      - build
+      - publish
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      checks: write # Create/reconcile the exact public provenance check only.
+    steps:
+      - name: Download distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-distribution
+          path: dist
+
+      # Do not trust only the preceding job result. Re-read public PyPI state in
+      # this checks-only, checkout-free job and bind the exact remote file.
+      - name: Verify exact PyPI wheel
+        id: wheel
+        shell: python
+        env:
+          PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
+        run: |
+          import hashlib
+          import json
+          import os
+          import time
+          import urllib.request
+          from email.parser import Parser
+          from pathlib import Path
+          from urllib.error import HTTPError
+          from urllib.parse import quote
+          from zipfile import ZipFile
+
+          wheels = list(Path("dist").glob("*.whl"))
+          if len(wheels) != 1:
+              raise RuntimeError(f"Expected one wheel, found {len(wheels)}")
+          wheel = wheels[0]
+          if any(character in wheel.name for character in "\r\n"):
+              raise RuntimeError("Wheel filename contains a line break")
+          local_digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+
+          package_version = os.environ["PACKAGE_VERSION"]
+          with ZipFile(wheel) as archive:
+              metadata_paths = [
+                  name
+                  for name in archive.namelist()
+                  if name.endswith(".dist-info/METADATA")
+              ]
+              if len(metadata_paths) != 1:
+                  raise RuntimeError(
+                      "Wheel must contain exactly one dist-info/METADATA file"
+                  )
+              metadata = Parser().parsestr(
+                  archive.read(metadata_paths[0]).decode("utf-8")
+              )
+          if (
+              metadata.get("Name") != "abeja-sdk"
+              or metadata.get("Version") != package_version
+          ):
+              raise RuntimeError("Wheel package identity differs from the release")
+
+          release = quote(package_version, safe="")
+          url = f"https://pypi.org/pypi/abeja-sdk/{release}/json"
+          last_error = "release not visible"
+          for attempt in range(1, 21):
+              try:
+                  with urllib.request.urlopen(url, timeout=10) as response:
+                      data = json.loads(response.read())
+              except HTTPError as error:
+                  if error.code != 404:
+                      raise
+                  last_error = "release not visible"
+              else:
+                  urls = data.get("urls") if isinstance(data, dict) else None
+                  if not isinstance(urls, list):
+                      raise RuntimeError("PyPI returned an invalid file list")
+                  if (
+                      len(urls) == 1
+                      and isinstance(urls[0], dict)
+                      and urls[0].get("filename") == wheel.name
+                  ):
+                      remote = urls[0]
+                      digests = remote.get("digests")
+                      remote_digest = (
+                          digests.get("sha256")
+                          if isinstance(digests, dict)
+                          else None
+                      )
+                      if remote.get("yanked") is True:
+                          raise RuntimeError(f"PyPI wheel is yanked: {wheel.name}")
+                      if remote_digest != local_digest:
+                          raise RuntimeError(
+                              f"PyPI wheel digest differs: {wheel.name}"
+                          )
+                      break
+                  filenames = [
+                      item.get("filename") if isinstance(item, dict) else None
+                      for item in urls
+                  ]
+                  last_error = f"unexpected file set: {filenames}"
+
+              if attempt == 20:
+                  raise RuntimeError(
+                      f"PyPI distribution was not verified: {last_error}"
+                  )
+              time.sleep(6)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"filename={wheel.name}\n")
+              output.write(f"sha256={local_digest}\n")
+
+      # This is intentionally inline and checkout-free. The public check-run
+      # contract lets platform-system-test bind the dispatch to the exact PyPI
+      # file verified by this release attempt.
+      - name: Record verified release provenance check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
+          RELEASE_STAGE: ${{ needs.build.outputs.release-stage }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.publish.outputs.run-attempt }}
+          WHEEL_FILENAME: ${{ steps.wheel.outputs.filename }}
+          WHEEL_SHA256: ${{ steps.wheel.outputs.sha256 }}
+        run: |
+          set -Eeuo pipefail
+
+          check_name="ABEJA SDK release provenance"
+          output_title="ABEJA SDK release provenance v1"
+          schema="abeja-sdk-release-provenance/v1"
+          external_id_prefix="abeja-sdk-release-provenance:v1"
+          source_workflow=".github/workflows/release.yml"
+
+          if [ "$GITHUB_REPOSITORY" != "abeja-inc/abeja-platform-sdk" ] ||
+            [ "$GITHUB_SERVER_URL" != "https://github.com" ] ||
+            [[ ! "$GITHUB_RUN_ID" =~ ^[1-9][0-9]*$ ]] ||
+            [[ ! "$GITHUB_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] ||
+            [[ ! "$SOURCE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] ||
+            [[ ! "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+            [[ ! "$WHEEL_SHA256" =~ ^[0-9a-f]{64}$ ]] ||
+            [[ "$WHEEL_FILENAME" == *$'\n'* ]] ||
+            [[ "$WHEEL_FILENAME" == *$'\r'* ]]; then
+            echo "Release provenance identity is invalid." >&2
+            exit 1
+          fi
+
+          if [ "$SOURCE_RUN_ATTEMPT" -gt "$GITHUB_RUN_ATTEMPT" ]; then
+            echo "Publish attempt cannot be newer than this job attempt." >&2
+            exit 1
+          fi
+          case "$RELEASE_STAGE" in
+            staging)
+              version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)rc(0|[1-9][0-9]*)$'
+              ;;
+            production)
+              version_pattern='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+              ;;
+            *)
+              echo "Release provenance stage is invalid: $RELEASE_STAGE" >&2
+              exit 1
+              ;;
+          esac
+          if [[ ! "$PACKAGE_VERSION" =~ $version_pattern ]]; then
+            echo "Release provenance version is invalid: $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+          external_id="$external_id_prefix:$GITHUB_RUN_ID:$SOURCE_RUN_ATTEMPT:$PACKAGE_VERSION:$WHEEL_SHA256"
+          logical_external_id_prefix="$external_id_prefix:$GITHUB_RUN_ID:$SOURCE_RUN_ATTEMPT:$PACKAGE_VERSION:"
+          details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT"
+          if [ "${#external_id}" -gt 255 ]; then
+            echo "Release provenance external_id exceeds 255 characters." >&2
+            exit 1
+          fi
+
+          summary="$(
+            jq -cSn \
+              --arg schema "$schema" \
+              --arg package "abeja-sdk" \
+              --arg package_version "$PACKAGE_VERSION" \
+              --arg release_stage "$RELEASE_STAGE" \
+              --arg wheel_filename "$WHEEL_FILENAME" \
+              --arg wheel_sha256 "$WHEEL_SHA256" \
+              --arg source_repository "$GITHUB_REPOSITORY" \
+              --arg source_workflow "$source_workflow" \
+              --arg source_run_id "$GITHUB_RUN_ID" \
+              --arg source_run_attempt "$SOURCE_RUN_ATTEMPT" \
+              --arg source_head_sha "$GITHUB_SHA" \
+              '{
+                schema: $schema,
+                package: $package,
+                package_version: $package_version,
+                release_stage: $release_stage,
+                wheel_filename: $wheel_filename,
+                wheel_sha256: $wheel_sha256,
+                source_repository: $source_repository,
+                source_workflow: $source_workflow,
+                source_run_id: $source_run_id,
+                source_run_attempt: $source_run_attempt,
+                source_head_sha: $source_head_sha
+              }'
+          )"
+
+          expected_contract="$(
+            jq -Scn \
+              --arg name "$check_name" \
+              --arg head_sha "$GITHUB_SHA" \
+              --arg external_id "$external_id" \
+              --arg details_url "$details_url" \
+              --arg title "$output_title" \
+              --arg summary "$summary" \
+              '{
+                app_slug: "github-actions",
+                name: $name,
+                head_sha: $head_sha,
+                external_id: $external_id,
+                details_url: $details_url,
+                status: "completed",
+                conclusion: "success",
+                output: {
+                  title: $title,
+                  summary: $summary
+                }
+              }'
+          )"
+
+          # Reconcile by the logical publication identity, not only the exact
+          # digest. A prior record with different evidence is a conflict and
+          # must never be hidden by creating a second successful check.
+          matches="$(
+            gh api --paginate --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs" \
+              -f "check_name=$check_name" \
+              -f "filter=all" \
+              -f "per_page=100" \
+              | jq -c --arg prefix "$logical_external_id_prefix" '
+                  .check_runs[]
+                  | select(
+                      (.external_id | type) == "string"
+                      and (.external_id | startswith($prefix))
+                    )
+                '
+          )"
+          match_count="$(
+            printf '%s\n' "$matches" |
+              awk 'NF { count++ } END { print count + 0 }'
+          )"
+          if [ "$match_count" -gt 1 ]; then
+            echo "Multiple release provenance checks have logical identity $logical_external_id_prefix." >&2
+            exit 1
+          fi
+
+          if [ "$match_count" -eq 1 ]; then
+            response="$matches"
+            operation="Reusing"
+          else
+            payload="$(
+              jq -n \
+                --arg name "$check_name" \
+                --arg head_sha "$GITHUB_SHA" \
+                --arg external_id "$external_id" \
+                --arg details_url "$details_url" \
+                --arg title "$output_title" \
+                --arg summary "$summary" \
+                '{
+                  name: $name,
+                  head_sha: $head_sha,
+                  external_id: $external_id,
+                  details_url: $details_url,
+                  status: "completed",
+                  conclusion: "success",
+                  output: {
+                    title: $title,
+                    summary: $summary
+                  }
+                }'
+            )"
+            response="$(
+              printf '%s' "$payload" |
+                gh api --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2026-03-10" \
+                  "repos/$GITHUB_REPOSITORY/check-runs" \
+                  --input -
+            )"
+            operation="Created"
+          fi
+
+          actual_contract="$(
+            printf '%s' "$response" |
+              jq -Sc '{
+                app_slug: .app.slug,
+                name: .name,
+                head_sha: .head_sha,
+                external_id: .external_id,
+                details_url: .details_url,
+                status: .status,
+                conclusion: .conclusion,
+                output: {
+                  title: .output.title,
+                  summary: .output.summary
+                }
+              }'
+          )"
+          if [ "$actual_contract" != "$expected_contract" ]; then
+            echo "Existing or created release provenance check differs from the contract." >&2
+            exit 1
+          fi
+
+          check_url="$(printf '%s' "$response" | jq -er '.html_url')"
+          echo "$operation verified release provenance check: $check_url" \
+            >> "$GITHUB_STEP_SUMMARY"
+
   trigger-system-tests:
     name: Trigger platform system tests
     needs:
       - build
       - publish
+      - record-release-provenance
       - system-test-readiness
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/tests/tools/test_github_actions_workflows.py
+++ b/tests/tools/test_github_actions_workflows.py
@@ -232,12 +232,13 @@ def test_verified_release_provenance_check_binds_the_published_wheel():
     assert "id-token:" not in provenance
     assert "actions/checkout@" not in publish
     assert "actions/checkout@" not in provenance
-    assert (
-        publish.index("Check existing PyPI distribution")
-        < publish.index("Publish distribution")
-        < publish.index("Verify published distribution")
-        < publish.index("Record successful publish attempt")
-    )
+    publish_step_positions = [
+        publish.index("Check existing PyPI distribution"),
+        publish.index("Publish distribution"),
+        publish.index("Verify published distribution"),
+        publish.index("Record successful publish attempt"),
+    ]
+    assert publish_step_positions == sorted(publish_step_positions)
     assert (
         "run-attempt: ${{ steps.publish-attempt.outputs.run-attempt }}"
         in publish

--- a/tests/tools/test_github_actions_workflows.py
+++ b/tests/tools/test_github_actions_workflows.py
@@ -153,7 +153,7 @@ def test_release_ref_must_still_be_the_current_branch_head():
         "  system-test-readiness:", 1
     )[0]
     publish = release.split("  publish:", 1)[1].split(
-        "  trigger-system-tests:", 1
+        "  record-release-provenance:", 1
     )[0]
 
     assert "Verify release source is the current branch head" in build
@@ -195,7 +195,12 @@ def test_system_test_dispatch_waits_for_publish_and_forwards_the_contract():
     release = (WORKFLOWS / "release.yml").read_text()
     trigger = release.split("  trigger-system-tests:", 1)[1]
 
-    assert "      - build\n      - publish\n      - system-test-readiness" in trigger
+    assert (
+        "      - build\n"
+        "      - publish\n"
+        "      - record-release-provenance\n"
+        "      - system-test-readiness"
+    ) in trigger
     expected_fields = {
         'sdk_version=$SDK_VERSION',
         'release_stage=$RELEASE_STAGE',
@@ -209,6 +214,122 @@ def test_system_test_dispatch_waits_for_publish_and_forwards_the_contract():
     }
     for field in expected_fields:
         assert f'--field "{field}"' in trigger
+
+
+def test_verified_release_provenance_check_binds_the_published_wheel():
+    release = (WORKFLOWS / "release.yml").read_text()
+    publish = release.split("  publish:", 1)[1].split(
+        "  record-release-provenance:", 1
+    )[0]
+    provenance = release.split("  record-release-provenance:", 1)[1].split(
+        "  trigger-system-tests:", 1
+    )[0]
+
+    assert release.count("checks: write") == 1
+    assert "checks: write" not in publish
+    assert "checks: write" in provenance
+    assert "contents:" not in provenance
+    assert "id-token:" not in provenance
+    assert "actions/checkout@" not in publish
+    assert "actions/checkout@" not in provenance
+    assert (
+        publish.index("Check existing PyPI distribution")
+        < publish.index("Publish distribution")
+        < publish.index("Verify published distribution")
+        < publish.index("Record successful publish attempt")
+    )
+    assert (
+        "run-attempt: ${{ steps.publish-attempt.outputs.run-attempt }}"
+        in publish
+    )
+    assert (
+        "run: printf 'run-attempt=%s\\n' \"$GITHUB_RUN_ATTEMPT\" "
+        '>> "$GITHUB_OUTPUT"'
+    ) in publish
+    assert release.index("  publish:") < release.index(
+        "  record-release-provenance:"
+    )
+    assert release.index("  record-release-provenance:") < release.index(
+        "  trigger-system-tests:"
+    )
+    assert "Verify exact PyPI wheel" in provenance
+    assert 'metadata.get("Name") != "abeja-sdk"' in provenance
+    assert 'metadata.get("Version") != package_version' in provenance
+    assert "len(urls) == 1" in provenance
+    assert 'urls[0].get("filename") == wheel.name' in provenance
+    assert 'remote.get("yanked") is True' in provenance
+    assert "remote_digest != local_digest" in provenance
+    assert "filename={wheel.name}" in provenance
+    assert "sha256={local_digest}" in provenance
+    assert "retention-days: 31" in release
+    assert 'check_name="ABEJA SDK release provenance"' in provenance
+    assert 'output_title="ABEJA SDK release provenance v1"' in provenance
+    assert 'schema="abeja-sdk-release-provenance/v1"' in provenance
+    assert 'external_id_prefix="abeja-sdk-release-provenance:v1"' in provenance
+    assert "jq -cSn" in provenance
+    assert (
+        "SOURCE_RUN_ATTEMPT: ${{ needs.publish.outputs.run-attempt }}"
+        in provenance
+    )
+    assert (
+        'if [ "$SOURCE_RUN_ATTEMPT" -gt "$GITHUB_RUN_ATTEMPT" ]'
+        in provenance
+    )
+    assert 'case "$RELEASE_STAGE" in' in provenance
+    assert "version_pattern=" in provenance
+    assert (
+        'external_id="$external_id_prefix:$GITHUB_RUN_ID:$SOURCE_RUN_ATTEMPT:'
+        '$PACKAGE_VERSION:$WHEEL_SHA256"'
+    ) in provenance
+    assert (
+        'details_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/'
+        '$GITHUB_RUN_ID/attempts/$SOURCE_RUN_ATTEMPT"'
+    ) in provenance
+    assert '--arg source_run_id "$GITHUB_RUN_ID"' in provenance
+    assert (
+        '--arg source_run_attempt "$SOURCE_RUN_ATTEMPT"'
+        in provenance
+    )
+    for field in (
+        "package_version",
+        "release_stage",
+        "wheel_filename",
+        "wheel_sha256",
+        "source_repository",
+        "source_workflow",
+        "source_run_id",
+        "source_run_attempt",
+        "source_head_sha",
+    ):
+        assert f"{field}: ${field}" in provenance
+    assert 'app_slug: "github-actions"' in provenance
+    assert 'status: "completed"' in provenance
+    assert 'conclusion: "success"' in provenance
+
+
+def test_release_provenance_check_is_retry_safe_and_fails_on_conflicts():
+    release = (WORKFLOWS / "release.yml").read_text()
+    provenance = release.split("  record-release-provenance:", 1)[1].split(
+        "  trigger-system-tests:", 1
+    )[0]
+
+    assert "commits/$GITHUB_SHA/check-runs" in provenance
+    assert '-f "check_name=$check_name"' in provenance
+    assert '-f "filter=all"' in provenance
+    assert (
+        'logical_external_id_prefix="$external_id_prefix:$GITHUB_RUN_ID:'
+        '$SOURCE_RUN_ATTEMPT:$PACKAGE_VERSION:"'
+    ) in provenance
+    assert 'jq -c --arg prefix "$logical_external_id_prefix"' in provenance
+    assert "startswith($prefix)" in provenance
+    assert "select(.external_id == $external_id)" not in provenance
+    assert 'if [ "$match_count" -gt 1 ]' in provenance
+    assert 'if [ "$match_count" -eq 1 ]' in provenance
+    assert 'operation="Reusing"' in provenance
+    assert 'operation="Created"' in provenance
+    assert "repos/$GITHUB_REPOSITORY/check-runs" in provenance
+    assert 'actual_contract" != "$expected_contract' in provenance
+    assert "differs from the contract" in provenance
 
 
 def test_system_test_dispatch_reconciles_retries_by_run_and_version():
@@ -234,6 +355,9 @@ def test_release_credentials_are_scoped_to_the_jobs_that_need_them():
         "  publish:", 1
     )[0]
     publish = release.split("  publish:", 1)[1].split(
+        "  record-release-provenance:", 1
+    )[0]
+    provenance = release.split("  record-release-provenance:", 1)[1].split(
         "  trigger-system-tests:", 1
     )[0]
     trigger = release.split("  trigger-system-tests:", 1)[1].split(
@@ -249,13 +373,21 @@ def test_release_credentials_are_scoped_to_the_jobs_that_need_them():
         "      contents: read"
     ) in publish
     assert "id-token: write" in publish
+    assert "checks: write" not in publish
+    assert (
+        "    permissions:\n"
+        "      checks: write # Create/reconcile the exact public provenance check only.\n"
+        "    steps:"
+    ) in provenance
+    assert "contents:" not in provenance
+    assert "id-token:" not in provenance
     assert "    permissions:\n      contents: write" in finalize
 
 
 def test_pypi_uses_protected_environment_and_trusted_publishing():
     release = (WORKFLOWS / "release.yml").read_text()
     publish = release.split("  publish:", 1)[1].split(
-        "  trigger-system-tests:", 1
+        "  record-release-provenance:", 1
     )[0]
 
     assert "name: pypi-${{ needs.build.outputs.release-stage }}" in publish


### PR DESCRIPTION
## Summary

- add a checkout-free, Checks-only job after PyPI publication and before the platform system-test dispatch
- re-verify the wheel's embedded package identity, filename, SHA-256, and non-yanked PyPI state
- record an exact, retry-safe GitHub Check Run contract that binds the package version and digest to the successful publish run attempt
- fail closed on duplicate or conflicting provenance and retain the build artifact for the full workflow rerun window

This closes the release-boundary gap found while preparing the `develop → staging` review PR. The corresponding `platform-system-test` receiver update is tracked in abeja-inc/platform-system-test#332.

## Security and retry behavior

- PyPI Trusted Publishing stays isolated in the checkout-free `publish` job with `id-token: write` only where required.
- `checks: write` is granted only to the separate checkout-free provenance job.
- Rerunning only downstream failed jobs reuses the successful Publish job's original attempt and the identical Check Run.
- Rerunning the Publish job records a new attempt; conflicting evidence is rejected.

## Validation

- `uv run --no-project --python 3.8 --with pytest==5.4.2 -- python -m pytest -q --confcutdir=tests/tools tests/tools` — 40 passed
- `git diff --check` — passed
- GitHub Actions policy validator — 0 errors / 0 warnings
- zizmor — no findings
- action pins/comments validated; local actionlint still does not recognize GitHub's current `queue: max` and `vulnerability-alerts` syntax

Refs #112
