### PR TITLE
Address PR #121 CI migration review feedback

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -1,7 +1,7 @@
 # GitHub Actions operations
 
 This repository uses separate workflows for unit tests, live integration tests,
-and package releases.
+package releases, and Firebase Hosting documentation deployments.
 
 The first migration pull request deliberately kept `.circleci/config.yml` and
 `tools/trigger_build_system_test.py` so the old and new test paths could be
@@ -14,9 +14,10 @@ never restore both publishers on a release branch.
 - `Unit tests` runs `make test` on Python 3.8. Its aggregate job always emits
   the stable `Unit tests` check and fails unless the implementation job
   succeeds. Make that exact check required in branch protection for `develop`,
-  `staging`, and `master`. Stale runs are cancelled per pull request or ref
-  using a static concurrency prefix that cannot collide with a reusable
-  workflow caller's own group.
+  `staging`, and `master`. Only stale pull-request runs are cancelled. Push and
+  reusable invocations never cancel an in-progress unit run. Release callers
+  are serialized by the outer release queue; a standalone unit workflow keeps
+  GitHub's default single pending slot.
 - `Integration tests` runs against a live, dedicated Datalake channel. It is
   serialized across the repository because every test deletes all files in the
   configured channel. Pending runs are queued instead of replacing one another.
@@ -31,8 +32,9 @@ never restore both publishers on a release branch.
   `platform-system-test`. Integration credentials are mandatory in this release
   path. A successful release means that the target registered the uniquely
   identified dispatch; it does not wait for the target run to finish. A retry
-  first reconciles both the provenance check and target runs, and fails on
-  duplicate or conflicting state. On `master`, a final checkout-free job then
+  first reconciles both the provenance check and target runs owned by the
+  configured dispatch GitHub App, and fails on duplicate or conflicting state.
+  On `master`, a final checkout-free job then
   reconciles the immutable tag and GitHub Release through the API. An identical
   existing tag/release is a safe no-op; a conflicting target or release
   metadata fails closed.
@@ -46,9 +48,9 @@ matrix. Upgrade the development dependencies before expanding the matrix.
 | Event | Eligible refs / callers | Trust and credentials | Jobs and side effects |
 | --- | --- | --- | --- |
 | `pull_request` | Targets `develop`, `staging`, or `master` | Unit tests are unprivileged. Integration receives local Environment secrets only for a same-repository, non-Dependabot head. | Stable `Unit tests` gate; optional serialized integration test; no writes. |
-| `push` | `develop` for tests; `staging` and `master` for release | Protected repository code. Integration uses its Environment; OIDC publishing, Checks write, and dispatch credentials remain in separate checkout-free jobs. | Tests on `develop`; serialized build/publish/provenance-check/dispatch on release branches; production tag/release reconciliation on `master`. |
-| `workflow_dispatch` | Unit: any ref, no secrets. Integration: only the three named branches. | Integration is skipped before Environment access for every other ref. | Manual validation only; no package publication. |
-| `workflow_call` | Unit: public reusable workflow. Integration: same repository only, with the original event/ref restrictions still enforced. | The release caller forwards no secrets. The integration job resolves this repository's protected Environment secrets only after its repository guard passes. | Test jobs only. The static unit concurrency prefix cannot cancel its caller. |
+| `push` | `develop` for tests and dev documentation; `staging` and `master` for release; `master` for production documentation | Repository branch code. Production assumes that the `master` ruleset admitted only reviewed changes. Integration uses its Environment; OIDC publishing, Checks write, dispatch credentials, and Firebase OIDC remain in separate jobs. | Tests and automatic dev documentation deployment on `develop`; serialized build/publish/provenance-check/dispatch on release branches; production tag/release reconciliation and automatic production documentation deployment on `master`. |
+| `workflow_dispatch` | Unit: any ref, no secrets. Integration: only the three named branches. Firebase: dev only on `develop`, production only on `master`. | Integration is skipped before Environment access for every other ref. Firebase deploy jobs receive OIDC only on their exact eligible branch. | Manual validation, or an explicit documentation redeployment on the matching Firebase branch; no package publication. |
+| `workflow_call` | Unit: public reusable workflow. Integration: same repository only, with the original event/ref restrictions still enforced. | The release caller forwards no secrets. The integration job resolves this repository's protected Environment secrets only after its repository guard passes. | Test jobs only. Unit runs queue without cancelling an active release caller. |
 
 Release runs share the `abeja-sdk-pypi-release` queue. The queue retains at
 most 100 pending runs and does not guarantee dispatch order, so every release
@@ -61,6 +63,42 @@ external queue.
 ## Environments and secrets
 
 Create these GitHub Environments before enabling the workflows.
+
+### `firebase-hosting-dev` and `firebase-hosting-production`
+
+The Firebase workflows build the Sphinx documentation under `doc/source` and
+deploy `doc/build/html` to two Hosting sites in the shared
+`apf-mlops-docs` Firebase project:
+
+| Environment | Eligible branch | Firebase target | Hosting site | Approval |
+| --- | --- | --- | --- | --- |
+| `firebase-hosting-dev` | `develop` | `sdk-spec-dev` | `apf-mlops-docs-sdk-dev` | Automatic after a push |
+| `firebase-hosting-production` | `master` | `sdk-spec-prod` | `apf-mlops-docs-sdk` | Automatic after a reviewed pull request is merged |
+
+Restrict each Environment to its exact branch. Do not add a required
+Environment reviewer: review and approval of the pull request into `master` is
+the production approval gate, and the documentation deploy starts
+automatically after merge. Protect `master` with a ruleset that requires a pull
+request, at least one approval, resolution of review conversations, and the
+stable `Unit tests` check; direct pushes must not bypass that gate.
+
+Both sites intentionally share the Workload Identity Provider and
+`github-deploy@apf-mlops-docs.iam.gserviceaccount.com`. The Google Cloud trust
+policy admits this repository as a whole and deliberately does not distinguish
+Git refs. Firebase Hosting IAM is also intentionally shared between the dev and
+production sites in this one-project, multi-site design. The workflow ref
+guards and Environment deployment rules protect the normal deployment paths,
+but they are not a separate Google Cloud IAM boundary. Repository write access
+is therefore part of the accepted Firebase trust boundary. Splitting service
+accounts, refs, sites, or Firebase projects is a separate architecture change,
+not a prerequisite for this CI migration.
+
+The jobs request only `contents: read` and `id-token: write`; no Google Cloud
+service-account key is stored in GitHub. GitHub's OIDC assertion is exchanged
+through Workload Identity Federation for short-lived Google Cloud credentials.
+Keep the provider, service account, Firebase project, and deploy targets fixed
+unless the repository owner and the Firebase infrastructure owner review the
+trust-boundary change together.
 
 ### `sdk-integration-test`
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -30,106 +30,80 @@ jobs:
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          alert-lookup: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check Dependabot alerts severity
+      - name: Check Dependabot metadata severity
         id: severity
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
-          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_GROUP: ${{ steps.metadata.outputs.dependency-group }}
+          UPDATED_DEPENDENCIES: ${{ steps.metadata.outputs.updated-dependencies-json }}
         with:
           script: |
-            const prNumber = context.issue.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const updateType = process.env.UPDATE_TYPE || '';
-
-            // Get PR details to check for security labels
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber
-            });
-
-            // Check if this is a security update by looking at labels, title, or metadata
-            const isSecurityUpdate = pr.labels.some(label => 
-              label.name.toLowerCase().includes('security')
-            ) || pr.title.toLowerCase().includes('security') ||
-              updateType.includes('security');
-
-            console.log(`Is security update: ${isSecurityUpdate}`);
-
-            if (!isSecurityUpdate) {
-              console.log('Not a security update - skipping severity check');
-              return { severity: 'none', isHighOrCritical: false };
-            }
-
-            // For security updates, check vulnerability alerts
+            const rawMetadata = process.env.UPDATED_DEPENDENCIES || '';
+            let dependencies;
             try {
-              const { data: alerts } = await github.rest.dependabot.listAlertsForRepo({
-                owner,
-                repo,
-                state: 'open'
-              });
-
-              console.log(`Found ${alerts.length} open vulnerability alerts`);
-
-              // Check if this is a grouped PR
-              const isGroupPR = pr.title.toLowerCase().includes('group');
-
-              if (isGroupPR) {
-                // For grouped PRs, use the highest severity across all alerts
-                console.log('Grouped PR detected - checking all open alerts');
-
-                if (alerts.length > 0) {
-                  const severities = alerts.map(a => a.security_advisory.severity);
-                  const highestSeverity = severities.includes('critical') ? 'critical' :
-                                         severities.includes('high') ? 'high' :
-                                         severities.includes('medium') ? 'medium' : 'low';
-
-                  const isHighOrCritical = ['high', 'critical'].includes(highestSeverity);
-
-                  console.log(`Highest severity in group: ${highestSeverity}`);
-                  console.log(`Is High or Critical: ${isHighOrCritical}`);
-
-                  return { severity: highestSeverity, isHighOrCritical, isGroup: true };
-                }
-              } else {
-                // For individual PRs, match by package name
-                const packageMatch = pr.title.match(/bump\s+(.+?)\s+from/i);
-                const packageName = packageMatch ? packageMatch[1] : null;
-
-                if (packageName) {
-                  console.log(`Package name: ${packageName}`);
-
-                  const relevantAlerts = alerts.filter(alert => 
-                    alert.security_advisory.package.name === packageName
-                  );
-
-                  if (relevantAlerts.length > 0) {
-                    const severities = relevantAlerts.map(a => a.security_advisory.severity);
-                    const highestSeverity = severities.includes('critical') ? 'critical' :
-                                           severities.includes('high') ? 'high' :
-                                           severities.includes('medium') ? 'medium' : 'low';
-
-                    const isHighOrCritical = ['high', 'critical'].includes(highestSeverity);
-
-                    console.log(`Package: ${packageName}`);
-                    console.log(`Severity: ${highestSeverity}`);
-                    console.log(`Is High or Critical: ${isHighOrCritical}`);
-
-                    return { severity: highestSeverity, isHighOrCritical, isGroup: false };
-                  }
-                }
-              }
+              dependencies = JSON.parse(rawMetadata);
             } catch (error) {
-              console.log(`Could not fetch vulnerability alerts: ${error.message}`);
-              // If we can't fetch alerts, require manual review for safety
-              return { severity: 'unknown', isHighOrCritical: false };
+              console.log(`Could not parse Dependabot metadata: ${error.message}`);
+              return {
+                severity: 'unknown',
+                isHighOrCritical: false,
+                isGroup: false
+              };
             }
 
-            // If no matching alerts found, require manual review
-            console.log('No matching vulnerability alerts found - requiring manual review');
-            return { severity: 'unknown', isHighOrCritical: false };
+            if (!Array.isArray(dependencies) || dependencies.length === 0) {
+              console.log('Dependabot returned no updated dependency metadata');
+              return {
+                severity: 'unknown',
+                isHighOrCritical: false,
+                isGroup: false
+              };
+            }
+
+            const isGroup = Boolean(process.env.DEPENDENCY_GROUP) ||
+              dependencies.length > 1;
+            const alerts = dependencies.map(dependency => ({
+              dependencyName: dependency.dependencyName,
+              alertState: dependency.alertState,
+              ghsaId: dependency.ghsaId,
+              cvss: Number(dependency.cvss)
+            }));
+            const allDependenciesHaveOpenAlerts = alerts.every(alert =>
+              typeof alert.dependencyName === 'string' &&
+              alert.dependencyName.length > 0 &&
+              alert.alertState === 'OPEN' &&
+              /^GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}$/i.test(alert.ghsaId) &&
+              Number.isFinite(alert.cvss) &&
+              alert.cvss > 0 &&
+              alert.cvss <= 10
+            );
+
+            if (!allDependenciesHaveOpenAlerts) {
+              console.log(
+                'At least one updated dependency lacks a matching open alert; ' +
+                'requiring manual review'
+              );
+              return {
+                severity: 'unknown',
+                isHighOrCritical: false,
+                isGroup
+              };
+            }
+
+            const highestCvss = Math.max(...alerts.map(alert => alert.cvss));
+            const severity = highestCvss >= 9 ? 'critical' :
+              highestCvss >= 7 ? 'high' :
+              highestCvss >= 4 ? 'medium' : 'low';
+            const isHighOrCritical = highestCvss >= 7;
+
+            console.log(`Matched dependency alerts: ${alerts.length}`);
+            console.log(`Highest CVSS score: ${highestCvss}`);
+            console.log(`Severity: ${severity}`);
+            return { severity, isHighOrCritical, isGroup };
 
       - name: Check auto-merge configuration
         id: check

--- a/.github/workflows/firebase-deploy-dev.yml
+++ b/.github/workflows/firebase-deploy-dev.yml
@@ -18,6 +18,7 @@ jobs:
     name: Deploy Firebase Hosting dev site
     if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
+    environment: firebase-hosting-dev
     permissions:
       contents: read
       id-token: write   # WIF の OIDC トークン発行に必須

--- a/.github/workflows/firebase-deploy-prod.yml
+++ b/.github/workflows/firebase-deploy-prod.yml
@@ -18,6 +18,7 @@ jobs:
     name: Deploy Firebase Hosting production site
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    environment: firebase-hosting-production
     permissions:
       contents: read
       id-token: write   # WIF の OIDC トークン発行に必須

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,6 +17,8 @@ permissions:
 
 env:
   POETRY_VERSION: "1.8.0"
+  # packaging 26.3 requires Python 3.9, while this SDK still tests Python 3.8.
+  POETRY_PACKAGING_VERSION: "26.2"
 
 jobs:
   integration-tests:
@@ -49,7 +51,7 @@ jobs:
           )
         )
       )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: sdk-integration-test
     concurrency:
@@ -85,7 +87,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Poetry
-        run: pipx install "poetry==${POETRY_VERSION}"
+        run: |
+          pipx install "poetry==${POETRY_VERSION}"
+          pipx runpip poetry install "packaging==${POETRY_PACKAGING_VERSION}"
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     needs:
       - unit-tests
       - integration-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
@@ -141,7 +141,7 @@ jobs:
   system-test-readiness:
     name: Verify platform system-test workflow
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions: {}
     environment: system-test-dispatch
@@ -251,7 +251,7 @@ jobs:
     needs:
       - build
       - system-test-readiness
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       run-attempt: ${{ steps.publish-attempt.outputs.run-attempt }}
@@ -277,7 +277,8 @@ jobs:
           enable-cache: "false"
 
       # Keep this inline so the credentialed job never executes checked-out
-      # repository code. The same rules are unit-tested in tools/.
+      # repository code. A test requires this block to match the unit-tested
+      # tools/check_pypi_distribution.py source byte for byte.
       - name: Check existing PyPI distribution
         id: pypi-state
         shell: python
@@ -292,63 +293,100 @@ jobs:
           from urllib.error import HTTPError
           from urllib.parse import quote
 
-          wheels = list(Path("dist").glob("*.whl"))
-          if len(wheels) != 1:
-              raise RuntimeError(f"Expected one wheel, found {len(wheels)}")
-          wheel = wheels[0]
 
-          package_version = os.environ["PACKAGE_VERSION"]
-          release = quote(package_version, safe="")
-          url = f"https://pypi.org/pypi/abeja-sdk/{release}/json"
-          missing = False
-          try:
-              with urllib.request.urlopen(url, timeout=10) as response:
-                  data = json.loads(response.read())
-          except HTTPError as error:
-              if error.code != 404:
-                  raise
-              missing = True
+          def get_pypi_release_files(package_name, version, urlopen=None):
+              opener = urlopen or urllib.request.urlopen
+              package = quote(package_name, safe="")
+              release = quote(version, safe="")
+              url = f"https://pypi.org/pypi/{package}/{release}/json"
 
-          if missing:
-              state = "missing"
-          else:
+              try:
+                  with opener(url, timeout=10) as response:
+                      data = json.loads(response.read())
+              except HTTPError as error:
+                  if error.code == 404:
+                      return None
+                  raise RuntimeError(
+                      f"Could not fetch {package_name} {version} from PyPI: {error}"
+                  ) from error
+              except Exception as error:
+                  raise RuntimeError(
+                      f"Could not fetch {package_name} {version} from PyPI: {error}"
+                  ) from error
+
               if not isinstance(data, dict):
                   raise RuntimeError("PyPI returned an invalid JSON object")
               urls = data.get("urls")
               if not isinstance(urls, list):
                   raise RuntimeError("PyPI returned an invalid file list")
-              if (
-                  len(urls) != 1
-                  or not isinstance(urls[0], dict)
-                  or urls[0].get("filename") != wheel.name
-              ):
+              return urls
+
+
+          def sha256sum(path):
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+          def get_distribution_state(
+              package_name,
+              version,
+              distribution_path,
+              urlopen=None,
+          ):
+              wheel = Path(distribution_path)
+              if not wheel.is_file():
+                  raise ValueError(f"Distribution does not exist: {wheel}")
+
+              remote_files = get_pypi_release_files(
+                  package_name,
+                  version,
+                  urlopen=urlopen,
+              )
+              if remote_files is None:
+                  return "missing"
+              remote = remote_files[0] if len(remote_files) == 1 else None
+              has_expected_file = isinstance(remote, dict)
+              if has_expected_file:
+                  has_expected_file = remote.get("filename") == wheel.name
+              if not has_expected_file:
                   filenames = [
                       item.get("filename") if isinstance(item, dict) else None
-                      for item in urls
+                      for item in remote_files
                   ]
-                  raise RuntimeError(
-                      f"PyPI has an unexpected file set: {filenames}"
-                  )
-              remote = urls[0]
+                  raise RuntimeError(f"PyPI has an unexpected file set: {filenames}")
+
               if remote.get("yanked") is True:
                   raise RuntimeError(f"PyPI wheel is yanked: {wheel.name}")
               digests = remote.get("digests")
               remote_digest = (
                   digests.get("sha256") if isinstance(digests, dict) else None
               )
-              local_digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
-              if remote_digest != local_digest:
+              if remote_digest != sha256sum(wheel):
                   raise RuntimeError(f"PyPI wheel digest differs: {wheel.name}")
-              state = "identical"
+              return "identical"
 
-          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
-              output.write(f"state={state}\n")
-          if state == "identical":
-              with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
-                  summary.write(
-                      "The identical wheel is already available on PyPI; "
-                      "upload is not repeated.\n"
-                  )
+
+          def main():
+              wheels = list(Path("dist").glob("*.whl"))
+              if len(wheels) != 1:
+                  raise RuntimeError(f"Expected one wheel, found {len(wheels)}")
+              state = get_distribution_state(
+                  "abeja-sdk",
+                  os.environ["PACKAGE_VERSION"],
+                  wheels[0],
+              )
+
+              with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+                  output.write(f"state={state}\n")
+              if state == "identical":
+                  with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+                      summary.write(
+                          "The identical wheel is already available on PyPI; "
+                          "upload is not repeated.\n"
+                      )
+
+
+          if __name__ == "__main__":
+              main()
 
       # Environment approval can take long enough for the release branch to
       # move after the build job's first check. Fence only a new upload here;
@@ -454,7 +492,7 @@ jobs:
     needs:
       - build
       - publish
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       checks: write # Create/reconcile the exact public provenance check only.
@@ -771,7 +809,7 @@ jobs:
       - publish
       - record-release-provenance
       - system-test-readiness
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions: {}
     environment: system-test-dispatch
@@ -788,6 +826,7 @@ jobs:
 
       - name: Dispatch platform-system-test workflow
         env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SDK_VERSION: ${{ needs.build.outputs.package-version }}
           RELEASE_STAGE: ${{ needs.build.outputs.release-stage }}
@@ -797,6 +836,11 @@ jobs:
           set -Eeuo pipefail
 
           expected_title="SDK $SDK_VERSION -> $RELEASE_STAGE (source $GITHUB_RUN_ID)"
+          if [[ ! "$APP_SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+            echo "GitHub App slug is missing or invalid." >&2
+            exit 1
+          fi
+          expected_actor="${APP_SLUG}[bot]"
           find_existing_dispatch() {
             local matches
             local match_count
@@ -806,9 +850,10 @@ jobs:
                 -f "branch=$TARGET_REF" \
                 -f "event=workflow_dispatch" \
                 -f "per_page=100" \
-                --jq '.workflow_runs[] | [.display_title, .html_url] | @tsv' \
+                --jq '.workflow_runs[] | [.display_title, .actor.login, .html_url] | @tsv' \
                 | awk -F '\t' -v expected="$expected_title" \
-                    '$1 == expected { print $2 }'
+                    -v actor="$expected_actor" \
+                    '$1 == expected && $2 == actor { print $3 }'
             )"
             match_count="$(
               printf '%s\n' "$matches" |
@@ -872,7 +917,7 @@ jobs:
       - build
       - publish
       - trigger-system-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: write # Required only to create the production tag/release.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,20 @@ permissions:
 
 env:
   POETRY_VERSION: "1.8.0"
+  # packaging 26.3 requires Python 3.9, while this SDK still tests Python 3.8.
+  POETRY_PACKAGING_VERSION: "26.2"
 
 # Keep this static prefix distinct from any reusable-workflow caller's group.
 concurrency:
   group: abeja-platform-sdk-unit-tests-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A release calls this workflow with the same staging/master ref as its
+  # caller. Only pull-request validation is safe to cancel as stale.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   unit-tests:
     name: Lint, types, and tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Check out repository
@@ -36,7 +40,9 @@ jobs:
 
       # Poetry must be available before setup-python initializes its Poetry cache.
       - name: Install Poetry
-        run: pipx install "poetry==${POETRY_VERSION}"
+        run: |
+          pipx install "poetry==${POETRY_VERSION}"
+          pipx runpip poetry install "packaging==${POETRY_PACKAGING_VERSION}"
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -55,7 +61,7 @@ jobs:
     name: Unit tests
     if: ${{ always() }}
     needs: unit-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions: {}
     steps:

--- a/tests/tools/test_check_pypi_distribution.py
+++ b/tests/tools/test_check_pypi_distribution.py
@@ -47,7 +47,7 @@ def test_distribution_state_is_missing_for_unknown_release(tmp_path):
     state = get_distribution_state(
         'abeja-sdk',
         '2.3.6',
-        [distribution],
+        distribution,
         urlopen=mock.Mock(side_effect=error),
     )
 
@@ -69,7 +69,7 @@ def test_distribution_state_fails_closed_for_pypi_error(tmp_path):
         get_distribution_state(
             'abeja-sdk',
             '2.3.6',
-            [distribution],
+            distribution,
             urlopen=mock.Mock(side_effect=error),
         )
 
@@ -84,7 +84,7 @@ def test_distribution_state_fails_closed_for_malformed_json(tmp_path):
         get_distribution_state(
             'abeja-sdk',
             '2.3.6',
-            [distribution],
+            distribution,
             urlopen=mock.Mock(return_value=response),
         )
 
@@ -99,7 +99,7 @@ def test_distribution_state_fails_closed_for_json_null(tmp_path):
         get_distribution_state(
             'abeja-sdk',
             '2.3.6',
-            [distribution],
+            distribution,
             urlopen=mock.Mock(return_value=response),
         )
 
@@ -113,7 +113,7 @@ def test_distribution_state_is_identical_for_matching_digest(tmp_path):
     state = get_distribution_state(
         'abeja-sdk',
         '2.3.6',
-        [distribution],
+        distribution,
         urlopen=mock.Mock(return_value=pypi_response(distribution.name, digest)),
     )
 
@@ -124,11 +124,11 @@ def test_distribution_state_rejects_different_digest(tmp_path):
     distribution = tmp_path / 'abeja_sdk-2.3.6-py3-none-any.whl'
     distribution.write_bytes(b'wheel')
 
-    with pytest.raises(RuntimeError, match='different or missing files'):
+    with pytest.raises(RuntimeError, match='wheel digest differs'):
         get_distribution_state(
             'abeja-sdk',
             '2.3.6',
-            [distribution],
+            distribution,
             urlopen=mock.Mock(
                 return_value=pypi_response(distribution.name, 'different')
             ),
@@ -145,7 +145,7 @@ def test_distribution_state_rejects_unexpected_extra_file(tmp_path):
         get_distribution_state(
             'abeja-sdk',
             '2.3.6',
-            [distribution],
+            distribution,
             urlopen=mock.Mock(
                 return_value=pypi_response_with_extra_file(
                     distribution.name,
@@ -161,11 +161,11 @@ def test_distribution_state_rejects_yanked_wheel(tmp_path):
     distribution.write_bytes(content)
     digest = hashlib.sha256(content).hexdigest()
 
-    with pytest.raises(RuntimeError, match='files are yanked'):
+    with pytest.raises(RuntimeError, match='wheel is yanked'):
         get_distribution_state(
             'abeja-sdk',
             '2.3.6',
-            [distribution],
+            distribution,
             urlopen=mock.Mock(
                 return_value=pypi_response(
                     distribution.name,

--- a/tests/tools/test_github_actions_workflows.py
+++ b/tests/tools/test_github_actions_workflows.py
@@ -6,6 +6,25 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
 
+def get_step_run(workflow, step_name):
+    lines = workflow.splitlines()
+    step_index = lines.index(f"      - name: {step_name}")
+    run_index = next(
+        index
+        for index in range(step_index + 1, len(lines))
+        if lines[index].startswith("        run: |")
+    )
+    run_indent = len(lines[run_index]) - len(lines[run_index].lstrip())
+    block_indent = run_indent + 2
+    block = []
+    for line in lines[run_index + 1:]:
+        indentation = len(line) - len(line.lstrip()) if line else block_indent
+        if line and indentation <= run_indent:
+            break
+        block.append(line[block_indent:] if line else "")
+    return "\n".join(block).rstrip()
+
+
 def test_release_and_live_integration_runs_are_queued():
     release = (WORKFLOWS / "release.yml").read_text()
     integration = (WORKFLOWS / "integration-test.yml").read_text()
@@ -103,12 +122,27 @@ def test_unit_workflow_has_noncolliding_stale_cancellation_and_stable_gate():
         "group: abeja-platform-sdk-unit-tests-"
         "${{ github.event.pull_request.number || github.ref }}"
     ) in unit
-    assert "cancel-in-progress: true" in unit
+    assert (
+        "cancel-in-progress: "
+        "${{ github.event_name == 'pull_request' }}"
+    ) in unit
     assert "name: Unit tests" in required
     assert "if: ${{ always() }}" in required
     assert "needs: unit-tests" in required
     assert 'run: test "$UNIT_TESTS_RESULT" = "success"' in required
     assert "permissions: {}" in required
+
+
+def test_poetry_runtime_stays_compatible_with_python_38():
+    for name in ("integration-test.yml", "test.yml"):
+        workflow = (WORKFLOWS / name).read_text()
+        install_poetry = get_step_run(workflow, "Install Poetry")
+
+        assert 'POETRY_PACKAGING_VERSION: "26.2"' in workflow
+        assert (
+            'pipx runpip poetry install '
+            '"packaging==${POETRY_PACKAGING_VERSION}"'
+        ) in install_poetry
 
 
 def test_integration_secrets_fail_closed_for_manual_and_external_callers():
@@ -345,6 +379,10 @@ def test_system_test_dispatch_reconciles_retries_by_run_and_version():
         '(source $GITHUB_RUN_ID)"'
     ) in trigger
     assert "display_title" in trigger
+    assert "steps.app-token.outputs.app-slug" in trigger
+    assert 'expected_actor="${APP_SLUG}[bot]"' in trigger
+    assert ".actor.login" in trigger
+    assert '$1 == expected && $2 == actor { print $3 }' in trigger
     assert "Found multiple matching system-test runs" in trigger
     assert "Matching system-test dispatch already exists" in trigger
     assert "System-test dispatch accepted" in trigger
@@ -412,6 +450,16 @@ def test_pypi_uses_protected_environment_and_trusted_publishing():
     assert "PyPI publication was not verified" in publish
 
 
+def test_pypi_preflight_runs_the_exact_unit_tested_script():
+    release = (WORKFLOWS / "release.yml").read_text()
+    tested_script = (ROOT / "tools" / "check_pypi_distribution.py").read_text()
+
+    assert get_step_run(
+        release,
+        "Check existing PyPI distribution",
+    ) == tested_script.rstrip()
+
+
 def test_privileged_workflow_run_is_removed_and_release_is_reconciled_inline():
     release = (WORKFLOWS / "release.yml").read_text()
     finalize = release.split("  finalize-production-release:", 1)[1]
@@ -458,3 +506,51 @@ def test_dependabot_alert_lookup_uses_the_matching_token_permission():
 
     assert "vulnerability-alerts: read" in workflow
     assert "security-events: read" not in workflow
+    assert "alert-lookup: true" in workflow
+    assert "updated-dependencies-json" in workflow
+    assert "dependency.alertState" in workflow
+    assert "dependency.ghsaId" in workflow
+    assert "dependency.cvss" in workflow
+    assert "allDependenciesHaveOpenAlerts" in workflow
+    assert "listAlertsForRepo" not in workflow
+    assert "pr.title" not in workflow
+    assert "pr.labels" not in workflow
+
+
+def test_migrated_workflows_use_supported_runner_image():
+    workflows = "\n".join(
+        (WORKFLOWS / name).read_text()
+        for name in (
+            "integration-test.yml",
+            "release.yml",
+            "test.yml",
+        )
+    )
+
+    assert "ubuntu-22.04" not in workflows
+    assert workflows.count("runs-on: ubuntu-24.04") == 9
+
+
+def test_firebase_deployments_use_branch_scoped_environments():
+    dev = (WORKFLOWS / "firebase-deploy-dev.yml").read_text()
+    production = (WORKFLOWS / "firebase-deploy-prod.yml").read_text()
+
+    assert "if: github.ref == 'refs/heads/develop'" in dev
+    assert "environment: firebase-hosting-dev" in dev
+    assert "if: github.ref == 'refs/heads/master'" in production
+    assert "environment: firebase-hosting-production" in production
+    for workflow in (dev, production):
+        assert "permissions: {}" in workflow.split("jobs:", 1)[0]
+        assert "contents: read" in workflow
+        assert "id-token: write" in workflow
+        assert "service_account: github-deploy@apf-mlops-docs.iam.gserviceaccount.com" in workflow
+
+
+def test_firebase_shared_trust_boundary_is_documented():
+    operations = (ROOT / ".github" / "CICD.md").read_text()
+    normalized = " ".join(operations.split())
+
+    assert "one-project, multi-site design" in normalized
+    assert "deliberately does not distinguish Git refs" in normalized
+    assert "review and approval of the pull request into `master`" in normalized
+    assert "Do not add a required Environment reviewer" in normalized

--- a/tools/check_pypi_distribution.py
+++ b/tools/check_pypi_distribution.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-"""Check whether local distributions are already published unchanged on PyPI."""
-
-import argparse
 import hashlib
 import json
-import sys
+import os
 import urllib.request
 from pathlib import Path
 from urllib.error import HTTPError
@@ -12,11 +8,10 @@ from urllib.parse import quote
 
 
 def get_pypi_release_files(package_name, version, urlopen=None):
-    """Return PyPI filename-to-SHA256 mappings, or None for a missing release."""
     opener = urlopen or urllib.request.urlopen
-    package = quote(package_name, safe='')
-    release = quote(version, safe='')
-    url = f'https://pypi.org/pypi/{package}/{release}/json'
+    package = quote(package_name, safe="")
+    release = quote(version, safe="")
+    url = f"https://pypi.org/pypi/{package}/{release}/json"
 
     try:
         with opener(url, timeout=10) as response:
@@ -24,99 +19,84 @@ def get_pypi_release_files(package_name, version, urlopen=None):
     except HTTPError as error:
         if error.code == 404:
             return None
-        raise RuntimeError(f'Could not fetch {package_name} {version} from PyPI: {error}') from error
+        raise RuntimeError(
+            f"Could not fetch {package_name} {version} from PyPI: {error}"
+        ) from error
     except Exception as error:
-        raise RuntimeError(f'Could not fetch {package_name} {version} from PyPI: {error}') from error
+        raise RuntimeError(
+            f"Could not fetch {package_name} {version} from PyPI: {error}"
+        ) from error
 
     if not isinstance(data, dict):
-        raise RuntimeError(f'PyPI returned an invalid JSON object for {package_name} {version}')
-    urls = data.get('urls')
+        raise RuntimeError("PyPI returned an invalid JSON object")
+    urls = data.get("urls")
     if not isinstance(urls, list):
-        raise RuntimeError(f'PyPI returned an invalid file list for {package_name} {version}')
-
-    files = {}
-    for item in urls:
-        if not isinstance(item, dict) or not item.get('filename'):
-            continue
-        digests = item.get('digests')
-        files[item['filename']] = {
-            'sha256': digests.get('sha256') if isinstance(digests, dict) else None,
-            'yanked': item.get('yanked') is True,
-        }
-    return files
+        raise RuntimeError("PyPI returned an invalid file list")
+    return urls
 
 
 def sha256sum(path):
-    digest = hashlib.sha256()
-    with path.open('rb') as distribution:
-        for chunk in iter(lambda: distribution.read(1024 * 1024), b''):
-            digest.update(chunk)
-    return digest.hexdigest()
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def get_distribution_state(package_name, version, distribution_paths, urlopen=None):
-    """Return missing or identical; raise if PyPI contains different files."""
-    paths = [Path(path) for path in distribution_paths]
-    if not paths:
-        raise ValueError('At least one distribution path is required')
-    for path in paths:
-        if not path.is_file():
-            raise ValueError(f'Distribution does not exist: {path}')
+def get_distribution_state(
+    package_name,
+    version,
+    distribution_path,
+    urlopen=None,
+):
+    wheel = Path(distribution_path)
+    if not wheel.is_file():
+        raise ValueError(f"Distribution does not exist: {wheel}")
 
-    remote_files = get_pypi_release_files(package_name, version, urlopen=urlopen)
+    remote_files = get_pypi_release_files(
+        package_name,
+        version,
+        urlopen=urlopen,
+    )
     if remote_files is None:
-        return 'missing'
+        return "missing"
+    remote = remote_files[0] if len(remote_files) == 1 else None
+    has_expected_file = isinstance(remote, dict)
+    if has_expected_file:
+        has_expected_file = remote.get("filename") == wheel.name
+    if not has_expected_file:
+        filenames = [
+            item.get("filename") if isinstance(item, dict) else None
+            for item in remote_files
+        ]
+        raise RuntimeError(f"PyPI has an unexpected file set: {filenames}")
 
-    expected_files = {path.name for path in paths}
-    if set(remote_files) != expected_files:
-        raise RuntimeError(
-            f'PyPI has an unexpected file set for {package_name} {version}: '
-            f'expected {sorted(expected_files)}, found {sorted(remote_files)}'
-        )
-
-    mismatches = []
-    yanked = []
-    for path in paths:
-        remote_file = remote_files.get(path.name)
-        local_digest = sha256sum(path)
-        if remote_file and remote_file['yanked']:
-            yanked.append(path.name)
-        elif not remote_file or remote_file['sha256'] != local_digest:
-            mismatches.append(path.name)
-
-    if yanked:
-        raise RuntimeError(
-            f'PyPI files are yanked for {package_name} {version}: '
-            f'{", ".join(yanked)}'
-        )
-    if mismatches:
-        raise RuntimeError(
-            f'PyPI already has different or missing files for {package_name} {version}: '
-            f'{", ".join(mismatches)}'
-        )
-    return 'identical'
+    if remote.get("yanked") is True:
+        raise RuntimeError(f"PyPI wheel is yanked: {wheel.name}")
+    digests = remote.get("digests")
+    remote_digest = (
+        digests.get("sha256") if isinstance(digests, dict) else None
+    )
+    if remote_digest != sha256sum(wheel):
+        raise RuntimeError(f"PyPI wheel digest differs: {wheel.name}")
+    return "identical"
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--package', required=True)
-    parser.add_argument('--version', required=True)
-    parser.add_argument('distributions', nargs='+')
-    args = parser.parse_args()
+    wheels = list(Path("dist").glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"Expected one wheel, found {len(wheels)}")
+    state = get_distribution_state(
+        "abeja-sdk",
+        os.environ["PACKAGE_VERSION"],
+        wheels[0],
+    )
 
-    try:
-        state = get_distribution_state(
-            args.package,
-            args.version,
-            args.distributions,
-        )
-    except Exception as error:
-        print(f'Error: {error}', file=sys.stderr)
-        return 1
-
-    print(state)
-    return 0
+    with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+        output.write(f"state={state}\n")
+    if state == "identical":
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary:
+            summary.write(
+                "The identical wheel is already available on PyPI; "
+                "upload is not repeated.\n"
+            )
 
 
-if __name__ == '__main__':
-    sys.exit(main())
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- applies the actionable review feedback from #121 to the CI/CD migration
- adds branch-scoped Firebase Hosting Environments and documents the agreed shared IAM/WIF model
- hardens release dispatch reconciliation, Dependabot security auto-merge, and PyPI artifact checks
- moves migrated jobs to Ubuntu 24.04 and keeps Poetry compatible with the SDK's Python 3.8 runtime

## Why

These changes address the unresolved review findings on #121 before `develop` is promoted to `staging`. The Poetry runtime pin also fixes the Ubuntu 24.04 failure observed during live validation.

## Impact

Merging updates `develop` and triggers the existing Firebase dev-site deployment. Production remains unchanged until the reviewed `develop` to `staging` and subsequent `master` promotion flow runs.

## Validation

- Python 3.8 workflow tests: 22 passed
- flake8: passed
- filtered actionlint: passed; the unfiltered tool only reports its known lack of support for current `queue` and `vulnerability-alerts` syntax
- zizmor and pinned-Action verification: passed
- live Ubuntu 24.04 Unit tests on the identical tree: https://github.com/abeja-inc/abeja-platform-sdk/actions/runs/30994246174

Related: #121
