### PR TITLE
公開SDK証跡の認証方式を運用文書へ反映

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -147,12 +147,14 @@ non-yanked state against public PyPI. That job has only `checks: write`; the
 OIDC-enabled publish job does not receive Checks permission. It then creates a
 completed GitHub check run before dispatch. `platform-system-test` reads this
 check through the public Checks REST API and compares its wheel digest with
-PyPI before accepting the dispatch. The target authenticates that public read
-with its read-only CI GitHub App to avoid the low shared anonymous API rate
-limit; no SDK repository secret crosses the repository boundary.
-Before staging, install that separate read App on `abeja-platform-sdk` with
-Actions and Checks read access and verify the target can mint its downscoped
-token. This is distinct from the SDK-owned App that dispatches
+PyPI before accepting the dispatch. Because this SDK repository and its
+release evidence are public, the target performs that read without a GitHub
+credential. No CI read GitHub App, `CI_APP_CLIENT_ID`, or
+`CI_APP_PRIVATE_KEY` is required. The target fails closed if the anonymous API
+is unavailable, rate-limited, or returns incomplete evidence. The shared-IP
+anonymous rate limit is an accepted operational risk; retry the failed target
+run after the rate-limit reset rather than weakening provenance validation.
+This public evidence read is separate from the SDK-owned App that dispatches
 `platform-system-test`.
 
 The release-provenance contract is exact:


### PR DESCRIPTION
## 概要

`platform-system-test`が公開SDKのrelease証跡を検証する際の認証方式を、現在の実装と意思決定に合わせて更新します。

## 変更内容

- 廃止済みのCI読み取り専用GitHub Appと`CI_APP_CLIENT_ID` / `CI_APP_PRIVATE_KEY`を必要とする記述を削除
- public repositoryである`abeja-platform-sdk`のActions run、Check Run、PyPI証跡をcredentialなしで読む現在の方式を明記
- anonymous APIがrate limitや不完全な応答を返した場合はfail closedとし、reset後にtarget runを再実行する運用を明記
- SDKから`platform-system-test`を起動するdispatch用GitHub Appとは別の仕組みであることを明記

## 背景と影響

Organization Settingsを必要とするCI read Appは採用せず、公開SDK証跡を匿名REST APIで検証する方針へ移行済みです。`platform-system-test`のStaging実デプロイでもこの経路を含むcodetestとtrusted packageが成功しています。

このPRは運用文書だけを修正します。workflow、権限、Secrets、デプロイ処理の変更はありません。

## 検証

- `uv run --no-project --python 3.8 --with pytest==5.4.2 -- python -m pytest -q --confcutdir=tests/tools tests/tools`: 45 passed
- `git diff --check`: passed
- GitHub Actions policy validator: error 0 / warning 0
- `zizmor`: findingsなし
- `pinact`: passed
- `actionlint`: GitHubで有効な`concurrency.queue: max`と`vulnerability-alerts`をローカル版が未認識する既知の3件のみ

Refs #112
